### PR TITLE
Ensure that the gid is a string when submitted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vnite",
-  "version": "1.5.7",
+  "version": "1.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vnite",
-      "version": "1.5.7",
+      "version": "1.5.10",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.0",

--- a/src/renderer/src/components/AddGame.jsx
+++ b/src/renderer/src/components/AddGame.jsx
@@ -95,7 +95,7 @@ function Info() {
       return
     }
     if (gid) {
-      if (gid.toLowerCase().startsWith('ga')) {
+      if (String(gid).toLowerCase().startsWith('ga')) {
         try {
           const Gid = Number(gid.slice(2));
           setGID(Number(gid.slice(2)));


### PR DESCRIPTION
Fixes #73 
该修复只是简单的类型转换
建议将来将带 `ga` 的gid字符串和不带 `ga` 的数值分成两个变量处理