### PR TITLE
Fix search with title when using vndb api

### DIFF
--- a/src/main/scraper/vndb/common.ts
+++ b/src/main/scraper/vndb/common.ts
@@ -131,16 +131,21 @@ export async function getGameScreenshots(vnId: string): Promise<string[]> {
 }
 
 export async function getGameScreenshotsByTitle(title: string): Promise<string[]> {
-  const fields = ['screenshots{url}'] as const
+  const fields = ['titles{title}', 'screenshots{url}'] as const
 
   try {
     const data = await fetchVNDB({
       filters: ['search', '=', title],
-      fields,
-      results: 1
+      fields
     })
-
-    return data.results[0].screenshots.map((screenshot) => screenshot.url)
+    if (data.results.length > 0) {
+      let vn = data.results.find((result) =>
+        result.titles.some((titleJson) => titleJson.title.toLowerCase() === title.toLowerCase())
+      )
+      vn = vn || data.results[0]
+      return vn.screenshots.map((screenshot) => screenshot.url)
+    }
+    return []
   } catch (error) {
     console.error(`Error fetching images for VN ${title}:`, error)
     return []


### PR DESCRIPTION
修改了使用vndb api标题搜索的逻辑，修复使用其它数据源时Screenshots数据与游戏不匹配的问题。
与 #76 的第2项修复相似。