### PR TITLE
Auto close ContextMenu for addCollection and Attributes

### DIFF
--- a/src/renderer/src/components/Game/Config/AttributesDialog/main.tsx
+++ b/src/renderer/src/components/Game/Config/AttributesDialog/main.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogContent, DialogTrigger, DialogTitle, DialogHeader } from '@ui/dialog'
+import { Dialog, DialogContent, DialogTitle, DialogHeader } from '@ui/dialog'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@ui/tabs'
 import { cn } from '~/utils'
 import { Launcher } from './Launcher'
@@ -8,15 +8,14 @@ import { useDBSyncedState } from '~/hooks'
 
 export function AttributesDialog({
   gameId,
-  children
+  setIsOpen
 }: {
   gameId: string
-  children: React.ReactNode
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>
 }): JSX.Element {
   const [gameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
   return (
-    <Dialog>
-      <DialogTrigger className={cn('w-full')}>{children}</DialogTrigger>
+    <Dialog open={true} onOpenChange={(state) => setIsOpen(state)}>
       <DialogContent className={cn('w-[1000px] h-[700px] max-w-none flex flex-col')}>
         <DialogHeader>
           <DialogTitle>{`${gameName} - 属性`}</DialogTitle>

--- a/src/renderer/src/components/Game/Config/CollectionMenu/main.tsx
+++ b/src/renderer/src/components/Game/Config/CollectionMenu/main.tsx
@@ -8,10 +8,15 @@ import {
   DropdownMenuSubTrigger
 } from '@ui/dropdown-menu'
 import { useCollections } from '~/hooks'
-import { AddCollectionDialog } from '../../../dialog/AddCollectionDialog'
 import { cn } from '~/utils'
 
-export function CollectionMenu({ gameId }: { gameId: string }): JSX.Element {
+export function CollectionMenu({
+  gameId,
+  openAddCollectionDialog
+}: {
+  gameId: string
+  openAddCollectionDialog: () => void
+}): JSX.Element {
   const { collections, addGameToCollection, removeGameFromCollection } = useCollections()
   const gameInCollectionsId = Object.entries(collections)
     .filter(([, value]) => value.games.includes(gameId))
@@ -31,14 +36,12 @@ export function CollectionMenu({ gameId }: { gameId: string }): JSX.Element {
               ))}
             {Object.entries(collections).filter(([key]) => !gameInCollectionsId.includes(key))
               .length > 0 && <DropdownMenuSeparator />}
-            <AddCollectionDialog gameId={gameId}>
-              <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-                <div className={cn('flex flex-row gap-2 items-center w-full')}>
-                  <span className={cn('icon-[mdi--add] w-4 h-4')}></span>
-                  <div>新收藏</div>
-                </div>
-              </DropdownMenuItem>
-            </AddCollectionDialog>
+            <DropdownMenuItem onSelect={openAddCollectionDialog}>
+              <div className={cn('flex flex-row gap-2 items-center w-full')}>
+                <span className={cn('icon-[mdi--add] w-4 h-4')}></span>
+                <div>新收藏</div>
+              </div>
+            </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuPortal>
       </DropdownMenuSub>

--- a/src/renderer/src/components/Game/Config/main.tsx
+++ b/src/renderer/src/components/Game/Config/main.tsx
@@ -10,26 +10,40 @@ import { cn } from '~/utils'
 import { CollectionMenu } from './CollectionMenu'
 import { AttributesDialog } from './AttributesDialog'
 import { ManageMenu } from './ManageMenu'
+import React from 'react'
+import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
 
 export function Config({ gameId }: { gameId: string }): JSX.Element {
+  const [isAttributesDialogOpen, setIsAttributesDialogOpen] = React.useState(false)
+  const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline" size={'icon'} className="non-draggable">
-          <span className={cn('icon-[mdi--settings-outline] w-4 h-4')}></span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-44 mr-5">
-        <CollectionMenu gameId={gameId} />
-        <DropdownMenuSeparator />
-        <ManageMenu gameId={gameId} />
-        <DropdownMenuSeparator />
-        <AttributesDialog gameId={gameId}>
-          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size={'icon'} className="non-draggable">
+            <span className={cn('icon-[mdi--settings-outline] w-4 h-4')}></span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-44 mr-5">
+          <CollectionMenu
+            gameId={gameId}
+            openAddCollectionDialog={() => setIsAddCollectionDialogOpen(true)}
+          />
+          <DropdownMenuSeparator />
+          <ManageMenu gameId={gameId} />
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => setIsAttributesDialogOpen(true)}>
             <div>属性</div>
           </DropdownMenuItem>
-        </AttributesDialog>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {isAttributesDialogOpen && (
+        <AttributesDialog gameId={gameId} setIsOpen={setIsAttributesDialogOpen} />
+      )}
+      {isAddCollectionDialogOpen && (
+        <AddCollectionDialog gameId={gameId} setIsOpen={setIsAddCollectionDialogOpen} />
+      )}
+    </>
   )
 }

--- a/src/renderer/src/components/Librarybar/GameNav.tsx
+++ b/src/renderer/src/components/Librarybar/GameNav.tsx
@@ -3,39 +3,57 @@ import { cn } from '~/utils'
 import { useGameMedia, useDBSyncedState } from '~/hooks'
 import { GameNavCM } from '../contextMenu/GameNavCM'
 import { ContextMenu, ContextMenuTrigger } from '@ui/context-menu'
+import { AttributesDialog } from '../Game/Config/AttributesDialog'
+import React from 'react'
+import { AddCollectionDialog } from '../dialog/AddCollectionDialog'
 
 export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }): JSX.Element {
   const { mediaUrl: icon } = useGameMedia({ gameId, type: 'icon', noToastError: true })
   const { mediaUrl: _cover } = useGameMedia({ gameId, type: 'cover', noToastError: true })
   const { mediaUrl: _background } = useGameMedia({ gameId, type: 'background', noToastError: true })
   const [gameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
+  const [isAttributesDialogOpen, setIsAttributesDialogOpen] = React.useState(false)
+  const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
+
   return (
-    <ContextMenu>
-      <ContextMenuTrigger>
-        <Nav
-          variant="sidebar"
-          className={cn('text-xs p-3 h-5 rounded-none')}
-          to={`./games/${gameId}/${groupId}`}
-        >
-          <div className={cn('flex flex-row gap-2 items-center')}>
-            {icon ? (
-              <div className={cn('')}>
-                <img
-                  src={icon}
-                  alt="icon"
-                  className={cn(
-                    'w-[20px] h-[20px] rounded-[0.1rem] shadow-sm shadow-black/70 object-cover'
-                  )}
-                />
-              </div>
-            ) : (
-              <span className={cn('icon-[mdi--gamepad-variant] w-5 h-5')}></span>
-            )}
-            <div className={cn('truncate')}>{gameName}</div>
-          </div>
-        </Nav>
-      </ContextMenuTrigger>
-      <GameNavCM gameId={gameId} />
-    </ContextMenu>
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger>
+          <Nav
+            variant="sidebar"
+            className={cn('text-xs p-3 h-5 rounded-none')}
+            to={`./games/${gameId}/${groupId}`}
+          >
+            <div className={cn('flex flex-row gap-2 items-center')}>
+              {icon ? (
+                <div className={cn('')}>
+                  <img
+                    src={icon}
+                    alt="icon"
+                    className={cn(
+                      'w-[20px] h-[20px] rounded-[0.1rem] shadow-sm shadow-black/70 object-cover'
+                    )}
+                  />
+                </div>
+              ) : (
+                <span className={cn('icon-[mdi--gamepad-variant] w-5 h-5')}></span>
+              )}
+              <div className={cn('truncate')}>{gameName}</div>
+            </div>
+          </Nav>
+        </ContextMenuTrigger>
+        <GameNavCM
+          gameId={gameId}
+          openAttributesDialog={() => setIsAttributesDialogOpen(true)}
+          openAddCollectionDialog={() => setIsAddCollectionDialogOpen(true)}
+        />
+      </ContextMenu>
+      {isAttributesDialogOpen && (
+        <AttributesDialog gameId={gameId} setIsOpen={setIsAttributesDialogOpen} />
+      )}
+      {isAddCollectionDialogOpen && (
+        <AddCollectionDialog gameId={gameId} setIsOpen={setIsAddCollectionDialogOpen} />
+      )}
+    </>
   )
 }

--- a/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
@@ -6,6 +6,9 @@ import { GameNavCM } from '~/components/contextMenu/GameNavCM'
 import { useNavigate } from 'react-router-dom'
 import { useGameMedia, useGameIndexManager, useDBSyncedState } from '~/hooks'
 import { formatTimeToChinese, formatDateToChinese } from '~/utils'
+import { AttributesDialog } from '~/components/Game/Config/AttributesDialog'
+import React from 'react'
+import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
 
 export function BigGamePoster({
   gameId,
@@ -21,6 +24,8 @@ export function BigGamePoster({
   const gameData = gameIndex[gameId]
   const [lastRunDate] = useDBSyncedState('', `games/${gameId}/record.json`, ['lastRunDate'])
   const [gameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
+  const [isAttributesDialogOpen, setIsAttributesDialogOpen] = React.useState(false)
+  const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
 
   return (
     <HoverCard openDelay={250} closeDelay={100}>
@@ -81,8 +86,18 @@ export function BigGamePoster({
               </div>
             </div>
           </ContextMenuTrigger>
-          <GameNavCM gameId={gameId} />
+          <GameNavCM
+            gameId={gameId}
+            openAttributesDialog={() => setIsAttributesDialogOpen(true)}
+            openAddCollectionDialog={() => setIsAddCollectionDialogOpen(true)}
+          />
         </ContextMenu>
+        {isAttributesDialogOpen && (
+          <AttributesDialog gameId={gameId} setIsOpen={setIsAttributesDialogOpen} />
+        )}
+        {isAddCollectionDialogOpen && (
+          <AddCollectionDialog gameId={gameId} setIsOpen={setIsAddCollectionDialogOpen} />
+        )}
       </HoverCardTrigger>
       <HoverCardContent
         side="right"

--- a/src/renderer/src/components/Showcase/posters/GamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/GamePoster.tsx
@@ -6,6 +6,9 @@ import { GameNavCM } from '~/components/contextMenu/GameNavCM'
 import { useNavigate } from 'react-router-dom'
 import { useGameMedia, useGameIndexManager, useDBSyncedState } from '~/hooks'
 import { formatTimeToChinese, formatDateToChinese } from '~/utils'
+import React from 'react'
+import { AttributesDialog } from '~/components/Game/Config/AttributesDialog'
+import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
 
 export function GamePoster({
   gameId,
@@ -23,6 +26,8 @@ export function GamePoster({
   const gameData = gameIndex[gameId]
   const [playingTime] = useDBSyncedState(0, `games/${gameId}/record.json`, ['playingTime'])
   const [gameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
+  const [isAttributesDialogOpen, setIsAttributesDialogOpen] = React.useState(false)
+  const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
 
   return (
     <HoverCard openDelay={200} closeDelay={100}>
@@ -67,8 +72,18 @@ export function GamePoster({
               )}
             </HoverCardAnimation>
           </ContextMenuTrigger>
-          <GameNavCM gameId={gameId} />
+          <GameNavCM
+            gameId={gameId}
+            openAttributesDialog={() => setIsAttributesDialogOpen(true)}
+            openAddCollectionDialog={() => setIsAddCollectionDialogOpen(true)}
+          />
         </ContextMenu>
+        {isAttributesDialogOpen && (
+          <AttributesDialog gameId={gameId} setIsOpen={setIsAttributesDialogOpen} />
+        )}
+        {isAddCollectionDialogOpen && (
+          <AddCollectionDialog gameId={gameId} setIsOpen={setIsAddCollectionDialogOpen} />
+        )}
       </HoverCardTrigger>
       <HoverCardContent
         side="right"

--- a/src/renderer/src/components/contextMenu/GameNavCM/CollectionMenu.tsx
+++ b/src/renderer/src/components/contextMenu/GameNavCM/CollectionMenu.tsx
@@ -8,10 +8,15 @@ import {
   ContextMenuSubTrigger
 } from '@ui/context-menu'
 import { useCollections } from '~/hooks'
-import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
 import { cn } from '~/utils'
 
-export function CollectionMenu({ gameId }: { gameId: string }): JSX.Element {
+export function CollectionMenu({
+  gameId,
+  openAddCollectionDialog
+}: {
+  gameId: string
+  openAddCollectionDialog: () => void
+}): JSX.Element {
   const { collections, addGameToCollection, removeGameFromCollection } = useCollections()
 
   const gameInCollectionsId = Object.entries(collections)
@@ -35,14 +40,12 @@ export function CollectionMenu({ gameId }: { gameId: string }): JSX.Element {
             {Object.entries(collections).filter(([key]) => !gameInCollectionsId.includes(key))
               .length > 0 && <ContextMenuSeparator />}
 
-            <AddCollectionDialog gameId={gameId}>
-              <ContextMenuItem onSelect={(e) => e.preventDefault()}>
-                <div className={cn('flex flex-row gap-2 items-center w-full')}>
-                  <span className={cn('icon-[mdi--add] w-4 h-4')}></span>
-                  <div>新收藏</div>
-                </div>
-              </ContextMenuItem>
-            </AddCollectionDialog>
+            <ContextMenuItem onSelect={openAddCollectionDialog}>
+              <div className={cn('flex flex-row gap-2 items-center w-full')}>
+                <span className={cn('icon-[mdi--add] w-4 h-4')}></span>
+                <div>新收藏</div>
+              </div>
+            </ContextMenuItem>
           </ContextMenuSubContent>
         </ContextMenuPortal>
       </ContextMenuSub>
@@ -55,7 +58,7 @@ export function CollectionMenu({ gameId }: { gameId: string }): JSX.Element {
               {Object.entries(collections)
                 .filter(([key]) => gameInCollectionsId.includes(key))
                 .map(([key, value]) => (
-                  <ContextMenuItem key={key} onClick={() => removeGameFromCollection(key, gameId)}>
+                  <ContextMenuItem key={key} onSelect={() => removeGameFromCollection(key, gameId)}>
                     {value.name}
                   </ContextMenuItem>
                 ))}

--- a/src/renderer/src/components/contextMenu/GameNavCM/main.tsx
+++ b/src/renderer/src/components/contextMenu/GameNavCM/main.tsx
@@ -1,13 +1,20 @@
 import { ContextMenuContent, ContextMenuItem, ContextMenuSeparator } from '@ui/context-menu'
 import { cn } from '~/utils'
-import { AttributesDialog } from '../../Game/Config/AttributesDialog'
 import { ManageMenu } from './ManageMenu'
 import { CollectionMenu } from './CollectionMenu'
 import { StartGame } from '../../Game/StartGame'
 import { StopGame } from '../../Game/StopGame'
 import { useRunningGames } from '~/pages/Library/store'
 
-export function GameNavCM({ gameId }: { gameId: string }): JSX.Element {
+export function GameNavCM({
+  gameId,
+  openAttributesDialog,
+  openAddCollectionDialog
+}: {
+  gameId: string
+  openAttributesDialog: () => void
+  openAddCollectionDialog: () => void
+}): JSX.Element {
   const { runningGames } = useRunningGames()
 
   return (
@@ -20,15 +27,13 @@ export function GameNavCM({ gameId }: { gameId: string }): JSX.Element {
         )}
       </div>
       <ContextMenuSeparator />
-      <CollectionMenu gameId={gameId} />
+      <CollectionMenu gameId={gameId} openAddCollectionDialog={openAddCollectionDialog} />
       <ContextMenuSeparator />
       <ManageMenu gameId={gameId} />
       <ContextMenuSeparator />
-      <AttributesDialog gameId={gameId}>
-        <ContextMenuItem onSelect={(e) => e.preventDefault()}>
-          <div>属性</div>
-        </ContextMenuItem>
-      </AttributesDialog>
+      <ContextMenuItem onSelect={openAttributesDialog}>
+        <div>属性</div>
+      </ContextMenuItem>
     </ContextMenuContent>
   )
 }

--- a/src/renderer/src/components/dialog/AddCollectionDialog.tsx
+++ b/src/renderer/src/components/dialog/AddCollectionDialog.tsx
@@ -1,7 +1,6 @@
 import {
   Dialog,
   DialogContent,
-  DialogTrigger,
   DialogClose,
   DialogFooter,
   DialogDescription,
@@ -16,19 +15,19 @@ import { useState } from 'react'
 
 export function AddCollectionDialog({
   gameId,
-  children
+  setIsOpen
 }: {
   gameId: string
-  children: React.ReactNode
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>
 }): JSX.Element {
   const [name, setName] = useState('')
   const { addCollection } = useCollections()
   const addGameToNewCollection = (): void => {
     addCollection(name, gameId)
   }
+
   return (
-    <Dialog>
-      <DialogTrigger className={cn('w-full')}>{children}</DialogTrigger>
+    <Dialog open={true} onOpenChange={(state) => setIsOpen(state)}>
       <DialogContent className={cn('')}>
         <DialogHeader>
           <DialogTitle>新收藏</DialogTitle>


### PR DESCRIPTION
右键菜单选择行为（如新收藏或属性）后不会主动消失。
PS.
感觉右键菜单和弹出的页面耦合度过高，完全修改比较麻烦。
本次提交没有修改大结构和目录，只是将弹出的界面提高到了与右键菜单的同一层并传递信号函数。
或许之后能以此为基础完全解耦吧）