### PR TITLE
Some Fixes

### DIFF
--- a/src/renderer/src/components/Game/FilterAdder.tsx
+++ b/src/renderer/src/components/Game/FilterAdder.tsx
@@ -12,7 +12,7 @@ export function FilterAdder({
   value: string
   className?: string
 }): JSX.Element {
-  const { addFilter, updateFilter } = useFilterStore()
+  const { filter, addFilter, updateFilter } = useFilterStore()
   return (
     <Button
       variant="link"
@@ -24,7 +24,9 @@ export function FilterAdder({
         if (filed === 'releaseDate') {
           updateFilter(filed, [value, value])
         } else {
-          addFilter(filed, value)
+          if (!filter[filed]?.includes(value)) {
+            addFilter(filed, value)
+          }
         }
         toast.info(`已添加筛选器，${filed}: ${value}`)
       }}

--- a/src/renderer/src/components/Librarybar/Filter/main.tsx
+++ b/src/renderer/src/components/Librarybar/Filter/main.tsx
@@ -14,9 +14,9 @@ export function Filter({ children }: { children: React.ReactNode }): JSX.Element
   return (
     <Popover open={isFilterMenuOpen}>
       <Tooltip>
-        <TooltipTrigger>
-          <PopoverTrigger asChild>{children}</PopoverTrigger>
-        </TooltipTrigger>
+        <PopoverTrigger>
+          <TooltipTrigger asChild>{children}</TooltipTrigger>
+        </PopoverTrigger>
         <TooltipContent side="right">高级筛选</TooltipContent>
       </Tooltip>
       <PopoverContent side="right" className="w-80 h-screen">

--- a/src/renderer/src/pages/Library/main.tsx
+++ b/src/renderer/src/pages/Library/main.tsx
@@ -22,8 +22,12 @@ export function Library({ className }: { className?: string }): JSX.Element {
     })
   }, [])
   return (
-    <ResizablePanelGroup direction="horizontal" className={cn('w-full h-full', className)}>
-      <ResizablePanel defaultSize={18} maxSize={30} minSize={12}>
+    <ResizablePanelGroup
+      autoSaveId="LibraryPanelGroup"
+      direction="horizontal"
+      className={cn('w-full h-full', className)}
+    >
+      <ResizablePanel defaultSize={18} maxSize={26} minSize={10} className={cn('min-w-[150px]')}>
         <Librarybar />
       </ResizablePanel>
       <ResizableHandle />


### PR DESCRIPTION
1. 阻止 `FilterAdder` 重复添加相同的筛选条件
2. 修复筛选器的 `Tooltip` 不正常显示（关闭高级筛选后Tooltip重新出现不消失）
3. 为 `Librarybar` 增加最小宽度，修复宽度过小时的布局异常
4. 为 `Library#ResizablePanelGroup` 增加 `autoSaveId` 使得切换页面后原先 `Librarybar` 的占比能被记住