### PR TITLE
Optimize Score

### DIFF
--- a/src/renderer/src/utils/formatter.ts
+++ b/src/renderer/src/utils/formatter.ts
@@ -84,6 +84,8 @@ export function formatScoreToChinese(score: number): string {
   // If it is 10 points, return the integer directly
   if (score === 10) return '10 分'
 
+  if (score === 0) return '0 分'
+
   // Other fractions retain 1 decimal place
   return `${score.toFixed(1)} 分`
 }


### PR DESCRIPTION
1. 未评分的游戏打开评分界面将显示空输入框
2. 输入为空时确认评分为清除评分
3. 阻止了负数评分
4. 修复了原先代码中的一个小问题
https://github.com/ximu3/vnite/blob/50ab868ee8cbb9805767e5d3e4a9232730a27e48/src/renderer/src/components/Game/Header.tsx#L63-L71
如 `scoreNum` 为 9.999 时会 `preScore` 会是 10.0 而非 10