### PR TITLE
Optimize the BatchEditor

### DIFF
--- a/src/renderer/src/components/Librarybar/GameNav.tsx
+++ b/src/renderer/src/components/Librarybar/GameNav.tsx
@@ -9,8 +9,10 @@ import React from 'react'
 import { AddCollectionDialog } from '../dialog/AddCollectionDialog'
 import { useGameBatchEditorStore } from '../GameBatchEditor/store'
 import { BatchGameNavCM } from '../GameBatchEditor/BatchGameNavCM'
+import { useLocation } from 'react-router-dom'
 
 export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }): JSX.Element {
+  const location = useLocation()
   const [gameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
   const [isAttributesDialogOpen, setIsAttributesDialogOpen] = React.useState(false)
   const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
@@ -28,7 +30,7 @@ export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }
     if (event.ctrlKey || event.metaKey) {
       // If Ctrl/Command is held down, toggles the selection state
       if (isSelected) {
-        removeGameId(gameId)
+        if (!location.pathname.includes(`/games/${gameId}/${groupId}`)) removeGameId(gameId)
       } else {
         addGameId(gameId)
       }
@@ -47,7 +49,7 @@ export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }
               variant="sidebar"
               className={cn(
                 'text-xs p-3 h-5 rounded-none',
-                isSelected && isBatchMode && 'bg-accent text-accent-foreground'
+                isSelected && 'bg-accent text-accent-foreground'
               )}
               to={`./games/${gameId}/${groupId}`}
             >

--- a/src/renderer/src/components/Librarybar/main.tsx
+++ b/src/renderer/src/components/Librarybar/main.tsx
@@ -18,6 +18,9 @@ import { Filter } from './Filter'
 import { useFilterStore } from './Filter/store'
 import { isEqual } from 'lodash'
 import { create } from 'zustand'
+import { useLocation } from 'react-router-dom'
+import { useEffect } from 'react'
+import { useGameBatchEditorStore } from '../GameBatchEditor/store'
 
 interface LibrarybarStore {
   query: string
@@ -35,6 +38,7 @@ export const useLibrarybarStore = create<LibrarybarStore>((set) => ({
 }))
 
 export function Librarybar(): JSX.Element {
+  const location = useLocation()
   const [selectedGroup, setSelectedGroup] = useDBSyncedState('collection', 'config.json', [
     'others',
     'gameList',
@@ -42,6 +46,15 @@ export function Librarybar(): JSX.Element {
   ])
   const { query, setQuery } = useLibrarybarStore()
   const { toggleFilterMenu, filter } = useFilterStore()
+  const { clearGameIds, gameIds } = useGameBatchEditorStore()
+
+  useEffect(() => {
+    // clear batchEditor gameList when switching to a non-game-detail page and not in batchMode
+    if (!location.pathname.includes(`/library/games/`) && gameIds.length < 2) {
+      clearGameIds()
+    }
+  }, [location.pathname])
+
   return (
     <div className={cn('flex flex-col gap-6 bg-card w-full h-full pt-2')}>
       <div className={cn('flex flex-col gap-3 p-3 pb-0')}>


### PR DESCRIPTION
对批量编辑的功能稍微改了一点点
1. 在某个游戏的详情页时，阻止将该游戏移除批量选中列表
2. 被选中批量的游戏在仅有一个时也会显示而不是凑齐两个再显示
3. 跳转到非游戏详情页时，如果不处于批量编辑模式（选中两个以上游戏），清空批量选中列表