### PR TITLE
Support mixed types of save backups

### DIFF
--- a/src/main/adder/common.ts
+++ b/src/main/adder/common.ts
@@ -98,11 +98,11 @@ export async function addGameToDB({
     await setDBValue(`games/${dbId}/path.json`, ['#all'], {
       version: 2,
       gamePath: '',
-      savePath: [
-        // {
-        //   pathInGame: '',
-        //   pathInDB: ''
-        // }
+      savePathInGame: [
+        /** string */
+      ],
+      savePathInDB: [
+        /** string */
       ]
     })
     await setDBValue(`games/${dbId}/save.json`, ['#all'], {})
@@ -160,11 +160,11 @@ export async function addGameToDBWithoutMetadata(gamePath: string): Promise<void
   await setDBValue(`games/${dbId}/path.json`, ['#all'], {
     version: 2,
     gamePath: '',
-    savePath: [
-      // {
-      //   pathInGame: '',
-      //   pathInDB: ''
-      // }
+    savePathInGame: [
+      /** string */
+    ],
+    savePathInDB: [
+      /** string */
     ]
   })
   const gameName = gamePath.split('\\').pop()?.split('.')?.slice(0, -1).join('.')

--- a/src/main/adder/common.ts
+++ b/src/main/adder/common.ts
@@ -96,11 +96,14 @@ export async function addGameToDB({
       }
     })
     await setDBValue(`games/${dbId}/path.json`, ['#all'], {
+      version: 2,
       gamePath: '',
-      savePath: {
-        mode: 'folder',
-        folder: []
-      }
+      savePath: [
+        // {
+        //   pathInGame: '',
+        //   pathInDB: ''
+        // }
+      ]
     })
     await setDBValue(`games/${dbId}/save.json`, ['#all'], {})
   }
@@ -155,11 +158,14 @@ export async function addGameToDBWithoutMetadata(gamePath: string): Promise<void
     }
   })
   await setDBValue(`games/${dbId}/path.json`, ['#all'], {
-    gamePath: gamePath,
-    savePath: {
-      mode: 'folder',
-      folder: []
-    }
+    version: 2,
+    gamePath: '',
+    savePath: [
+      // {
+      //   pathInGame: '',
+      //   pathInDB: ''
+      // }
+    ]
   })
   const gameName = gamePath.split('\\').pop()?.split('.')?.slice(0, -1).join('.')
   await setDBValue(`games/${dbId}/metadata.json`, ['#all'], {

--- a/src/main/database/save.ts
+++ b/src/main/database/save.ts
@@ -4,9 +4,19 @@ import { getDataPath, generateUUID } from '~/utils'
 import fse from 'fs-extra'
 
 export async function upgradePathJson1to2(gameId: string): Promise<void> {
-  const gamePath = await getDBValue(`games/${gameId}/path.json`, ['gamePath'], '')
-  const savePathMode = await getDBValue(`games/${gameId}/path.json`, ['savePath', 'mode'], 'folder')
-  const savePath = await getDBValue(`games/${gameId}/path.json`, ['savePath', savePathMode], [''])
+  const gamePath = await getDBValue(`games/${gameId}/path.json`, ['gamePath'], '', true)
+  const savePathMode = await getDBValue(
+    `games/${gameId}/path.json`,
+    ['savePath', 'mode'],
+    'folder',
+    true
+  )
+  const savePath = await getDBValue(
+    `games/${gameId}/path.json`,
+    ['savePath', savePathMode],
+    [''],
+    true
+  )
 
   const newPathJson: {
     version: number

--- a/src/main/database/services.ts
+++ b/src/main/database/services.ts
@@ -3,7 +3,7 @@ import { BrowserWindow } from 'electron'
 import { getDataPath } from '~/utils'
 import { getGameIndex, updateGameIndex } from './gameIndex'
 import { getGameRecords, updateGameRecord } from './record'
-import { backupGameSave, restoreGameSave, deleteGameSave } from './save'
+import { backupGameSave, restoreGameSave, deleteGameSave, upgradePathJson1to2 } from './save'
 import { deleteGame } from './utils'
 import { backupDatabase, restoreDatabase } from './backup'
 import log from 'electron-log/main.js'
@@ -168,5 +168,18 @@ export async function restoreDatabaseData(sourcePath: string): Promise<void> {
   } catch (error) {
     log.error(`Failed to restore database from ${sourcePath}`, error)
     throw error
+  }
+}
+
+/**
+ * Check the version of `path.json` and upgrade it.
+ * @param gameId The id of the game
+ * @returns A promise that resolves when the operation is complete.
+ */
+export async function checkPathJsonVersion(gameId: string): Promise<void> {
+  const pathJsonVersion = await getDBValue(`games/${gameId}/path.json`, ['version'], 1)
+
+  if (pathJsonVersion === 1) {
+    await upgradePathJson1to2(gameId)
   }
 }

--- a/src/main/ipc/utils.ts
+++ b/src/main/ipc/utils.ts
@@ -43,15 +43,25 @@ export function setupUtilsIPC(mainWindow: BrowserWindow): void {
 
   ipcMain.handle(
     'select-path-dialog',
-    async (_, properties: NonNullable<OpenDialogOptions['properties']>, extensions?: string[]) => {
-      return await selectPathDialog(properties, extensions)
+    async (
+      _,
+      properties: NonNullable<OpenDialogOptions['properties']>,
+      extensions?: string[],
+      defaultPath?: string
+    ) => {
+      return await selectPathDialog(properties, extensions, defaultPath)
     }
   )
 
   ipcMain.handle(
     'select-multiple-path-dialog',
-    async (_, properties: NonNullable<OpenDialogOptions['properties']>, extensions?: string[]) => {
-      return await selectMultiplePathDialog(properties, extensions)
+    async (
+      _,
+      properties: NonNullable<OpenDialogOptions['properties']>,
+      extensions?: string[],
+      defaultPath?: string
+    ) => {
+      return await selectMultiplePathDialog(properties, extensions, defaultPath)
     }
   )
 

--- a/src/main/monitor/common.ts
+++ b/src/main/monitor/common.ts
@@ -4,7 +4,7 @@ import { ipcMain, IpcMainEvent, BrowserWindow } from 'electron'
 import { updateRecentGames } from '~/utils'
 import { setDBValue, getDBValue } from '~/database'
 import log from 'electron-log/main.js'
-import { backupGameSaveData, checkPathJsonVersion } from '~/database'
+import { backupGameSaveData } from '~/database'
 import { exec } from 'child_process'
 import iconv from 'iconv-lite'
 
@@ -396,7 +396,6 @@ export class GameMonitor {
 
     updateRecentGames()
 
-    await checkPathJsonVersion(this.options.gameId)
     const savePath = await getDBValue<{ pathInGame: string; pathInDB: string }[]>(
       `games/${this.options.gameId}/path.json`,
       ['savePath'],

--- a/src/main/monitor/common.ts
+++ b/src/main/monitor/common.ts
@@ -4,7 +4,7 @@ import { ipcMain, IpcMainEvent, BrowserWindow } from 'electron'
 import { updateRecentGames } from '~/utils'
 import { setDBValue, getDBValue } from '~/database'
 import log from 'electron-log/main.js'
-import { backupGameSaveData } from '~/database'
+import { backupGameSaveData, checkPathJsonVersion } from '~/database'
 import { exec } from 'child_process'
 import iconv from 'iconv-lite'
 
@@ -396,18 +396,14 @@ export class GameMonitor {
 
     updateRecentGames()
 
-    const savePathMode = await getDBValue(
+    await checkPathJsonVersion(this.options.gameId)
+    const savePath = await getDBValue<{ pathInGame: string; pathInDB: string }[]>(
       `games/${this.options.gameId}/path.json`,
-      ['savePath', 'mode'],
-      'folder'
-    )
-    const savePath = await getDBValue(
-      `games/${this.options.gameId}/path.json`,
-      ['savePath', savePathMode],
-      ['']
+      ['savePath'],
+      []
     )
 
-    if (savePath.length > 0 && savePath[0] !== '') {
+    if (savePath.length > 0 && savePath[0].pathInDB !== '' && savePath[0].pathInGame !== '') {
       await backupGameSaveData(this.options.gameId)
     }
   }

--- a/src/main/monitor/common.ts
+++ b/src/main/monitor/common.ts
@@ -396,13 +396,13 @@ export class GameMonitor {
 
     updateRecentGames()
 
-    const savePath = await getDBValue<{ pathInGame: string; pathInDB: string }[]>(
+    const savePathInGame = await getDBValue<string[]>(
       `games/${this.options.gameId}/path.json`,
-      ['savePath'],
+      ['savePathInGame'],
       []
     )
 
-    if (savePath.length > 0 && savePath[0].pathInDB !== '' && savePath[0].pathInGame !== '') {
+    if (savePathInGame.length > 0 && savePathInGame[0] !== '') {
       await backupGameSaveData(this.options.gameId)
     }
   }

--- a/src/main/utils/dialog.ts
+++ b/src/main/utils/dialog.ts
@@ -9,11 +9,13 @@ import { OpenDialogOptions } from 'electron'
  */
 export async function selectPathDialog(
   properties: NonNullable<OpenDialogOptions['properties']>,
-  extensions?: string[]
+  extensions?: string[],
+  defaultPath?: string
 ): Promise<string | undefined> {
   const result = await dialog.showOpenDialog({
     properties: properties,
-    filters: extensions ? [{ name: 'All Files', extensions: extensions }] : undefined
+    filters: extensions ? [{ name: 'All Files', extensions: extensions }] : undefined,
+    defaultPath: defaultPath
   })
   return result.filePaths[0]
 }
@@ -26,14 +28,16 @@ export async function selectPathDialog(
  */
 export async function selectMultiplePathDialog(
   properties: NonNullable<OpenDialogOptions['properties']>,
-  extensions?: string[]
+  extensions?: string[],
+  defaultPath?: string
 ): Promise<string[] | undefined> {
   if (!properties.includes('multiSelections')) {
     properties.push('multiSelections')
   }
   const result = await dialog.showOpenDialog({
     properties: properties,
-    filters: extensions ? [{ name: 'All Files', extensions: extensions }] : undefined
+    filters: extensions ? [{ name: 'All Files', extensions: extensions }] : undefined,
+    defaultPath: defaultPath
   })
   return result.filePaths
 }

--- a/src/renderer/src/components/Game/Config/AttributesDialog/Path/main.tsx
+++ b/src/renderer/src/components/Game/Config/AttributesDialog/Path/main.tsx
@@ -127,22 +127,38 @@ export function Path({ gameId }: { gameId: string }): JSX.Element {
                 className={cn('max-h-[400px] min-h-[100px]')}
               />
             </div>
-            <Button
-              variant={'outline'}
-              size={'icon'}
-              className={cn('-ml-3')}
-              onClick={selectSaveFolderPath}
-            >
-              <span className={cn('icon-[mdi--folder-open-outline] w-5 h-5')}></span>
-            </Button>
-            <Button
-              variant={'outline'}
-              size={'icon'}
-              className={cn('-ml-3')}
-              onClick={selectSaveFilePath}
-            >
-              <span className={cn('icon-[mdi--file-outline] w-5 h-5')}></span>
-            </Button>
+            <div className={cn('flex flex-col gap-3')}>
+              <Button
+                variant={'outline'}
+                size={'icon'}
+                className={cn('-ml-3 relative group/b1')}
+                onClick={selectSaveFolderPath}
+              >
+                <span className={cn('icon-[mdi--folder-plus-outline] w-5 h-5')}></span>
+                <span
+                  className={cn(
+                    'absolute hidden group-hover/b1:block text-xs left-full top-1/2 transform -translate-y-1/2 ml-2'
+                  )}
+                >
+                  添加文件夹
+                </span>
+              </Button>
+              <Button
+                variant={'outline'}
+                size={'icon'}
+                className={cn('-ml-3 relative group/b2')}
+                onClick={selectSaveFilePath}
+              >
+                <span className={cn('icon-[mdi--file-plus-outline] w-5 h-5')}></span>
+                <span
+                  className={cn(
+                    'absolute hidden group-hover/b2:block text-xs left-full top-1/2 transform -translate-y-1/2 ml-2'
+                  )}
+                >
+                  添加文件
+                </span>
+              </Button>
+            </div>
           </div>
         </div>
       </CardContent>

--- a/src/renderer/src/components/Game/Config/AttributesDialog/Path/main.tsx
+++ b/src/renderer/src/components/Game/Config/AttributesDialog/Path/main.tsx
@@ -73,14 +73,24 @@ export function Path({ gameId }: { gameId: string }): JSX.Element {
     }
   }
   async function selectSaveFolderPath(): Promise<void> {
-    const folderPath: string[] = await ipcInvoke('select-multiple-path-dialog', ['openDirectory'])
+    const folderPath: string[] = await ipcInvoke(
+      'select-multiple-path-dialog',
+      ['openDirectory'],
+      undefined,
+      gamePath
+    )
     if (!folderPath) {
       return
     }
     setSaveFolderPath(folderPath)
   }
   async function selectSaveFilePath(): Promise<void> {
-    const filePath: string[] = await ipcInvoke('select-multiple-path-dialog', ['openFile'])
+    const filePath: string[] = await ipcInvoke(
+      'select-multiple-path-dialog',
+      ['openFile'],
+      undefined,
+      gamePath
+    )
     if (!filePath) {
       return
     }

--- a/src/renderer/src/components/Game/Config/AttributesDialog/Path/main.tsx
+++ b/src/renderer/src/components/Game/Config/AttributesDialog/Path/main.tsx
@@ -1,15 +1,6 @@
 import { cn } from '~/utils'
 import { useDBSyncedState } from '~/hooks'
 import { Card, CardContent, CardHeader, CardTitle } from '@ui/card'
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue
-} from '@ui/select'
 import { Input } from '@ui/input'
 import { Button } from '@ui/button'
 import { ipcInvoke, canAccessImageFile } from '~/utils'
@@ -37,18 +28,19 @@ export function Path({ gameId }: { gameId: string }): JSX.Element {
     'timerPath'
   ])
   const [gamePath, setGamePath] = useDBSyncedState('', `games/${gameId}/path.json`, ['gamePath'])
-  const [saveMode, setSaveMode] = useDBSyncedState('folder', `games/${gameId}/path.json`, [
-    'savePath',
-    'mode'
-  ])
-  const [saveFolderPath, setSaveFolderPath] = useDBSyncedState([''], `games/${gameId}/path.json`, [
-    'savePath',
-    'folder'
-  ])
-  const [saveFilePath, setSaveFilePath] = useDBSyncedState([''], `games/${gameId}/path.json`, [
-    'savePath',
-    'file'
-  ])
+
+  const [_savePathInDB, setSavePathInDB] = useDBSyncedState<string[]>(
+    [],
+    `games/${gameId}/path.json`,
+    ['savePathInDB']
+  )
+
+  const [savePathInGame, setSavePathInGame] = useDBSyncedState<string[]>(
+    [],
+    `games/${gameId}/path.json`,
+    ['savePathInGame']
+  )
+
   async function selectGamePath(): Promise<void> {
     const filePath: string = await ipcInvoke('select-path-dialog', ['openFile'])
     if (!filePath) {
@@ -82,7 +74,8 @@ export function Path({ gameId }: { gameId: string }): JSX.Element {
     if (!folderPath) {
       return
     }
-    setSaveFolderPath(folderPath)
+    const newSavePathInGame = savePathInGame.concat(folderPath)
+    handlleSavePathInGameChange(newSavePathInGame)
   }
   async function selectSaveFilePath(): Promise<void> {
     const filePath: string[] = await ipcInvoke(
@@ -94,8 +87,16 @@ export function Path({ gameId }: { gameId: string }): JSX.Element {
     if (!filePath) {
       return
     }
-    setSaveFilePath(filePath)
+    const newSavePathInGame = savePathInGame.concat(filePath)
+    handlleSavePathInGameChange(newSavePathInGame)
   }
+
+  async function handlleSavePathInGameChange(value: string[]): Promise<void> {
+    await setSavePathInGame(value)
+    const newSavePathInDB = Array.from({ length: value.length }, () => '')
+    await setSavePathInDB(newSavePathInDB)
+  }
+
   return (
     <Card className={cn('group')}>
       <CardHeader>
@@ -117,62 +118,32 @@ export function Path({ gameId }: { gameId: string }): JSX.Element {
               <span className={cn('icon-[mdi--file-outline] w-5 h-5')}></span>
             </Button>
           </div>
-          <div className={cn('flex flex-row gap-5 items-center')}>
-            <div>存档模式</div>
-            <div className={cn('w-[120px]')}>
-              <Select value={saveMode} onValueChange={setSaveMode}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectLabel>存档模式</SelectLabel>
-                    <SelectItem value="folder">目录</SelectItem>
-                    <SelectItem value="file">文件</SelectItem>
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
+          <div className={cn('flex flex-row gap-5 items-start')}>
+            <div>存档路径</div>
+            <div className={cn('w-3/4')}>
+              <ArrayTextarea
+                value={savePathInGame}
+                onChange={handlleSavePathInGameChange}
+                className={cn('max-h-[400px] min-h-[100px]')}
+              />
             </div>
+            <Button
+              variant={'outline'}
+              size={'icon'}
+              className={cn('-ml-3')}
+              onClick={selectSaveFolderPath}
+            >
+              <span className={cn('icon-[mdi--folder-open-outline] w-5 h-5')}></span>
+            </Button>
+            <Button
+              variant={'outline'}
+              size={'icon'}
+              className={cn('-ml-3')}
+              onClick={selectSaveFilePath}
+            >
+              <span className={cn('icon-[mdi--file-outline] w-5 h-5')}></span>
+            </Button>
           </div>
-          {saveMode === 'folder' ? (
-            <div className={cn('flex flex-row gap-5 items-start')}>
-              <div>存档路径</div>
-              <div className={cn('w-3/4')}>
-                <ArrayTextarea
-                  value={saveFolderPath}
-                  onChange={setSaveFolderPath}
-                  className={cn('max-h-[400px] min-h-[100px]')}
-                />
-              </div>
-              <Button
-                variant={'outline'}
-                size={'icon'}
-                className={cn('-ml-3')}
-                onClick={selectSaveFolderPath}
-              >
-                <span className={cn('icon-[mdi--folder-open-outline] w-5 h-5')}></span>
-              </Button>
-            </div>
-          ) : (
-            <div className={cn('flex flex-row gap-5 items-start')}>
-              <div>存档路径</div>
-              <div className={cn('w-3/4')}>
-                <ArrayTextarea
-                  value={saveFilePath}
-                  onChange={setSaveFilePath}
-                  className={cn('max-h-[400px] min-h-[100px]')}
-                />
-              </div>
-              <Button
-                variant={'outline'}
-                size={'icon'}
-                className={cn('-ml-3')}
-                onClick={selectSaveFilePath}
-              >
-                <span className={cn('icon-[mdi--file-outline] w-5 h-5')}></span>
-              </Button>
-            </div>
-          )}
         </div>
       </CardContent>
     </Card>

--- a/src/renderer/src/components/Game/Save/main.tsx
+++ b/src/renderer/src/components/Game/Save/main.tsx
@@ -14,10 +14,11 @@ export function Save({ gameId }: { gameId: string }): JSX.Element {
     `games/${gameId}/save.json`,
     ['#all']
   )
-  const [savePathMode] = useDBSyncedState('', `games/${gameId}/path.json`, ['savePath', 'mode'])
-  const [savePath] = useDBSyncedState([''], `games/${gameId}/path.json`, ['savePath', savePathMode])
+
+  const [savePathInGame] = useDBSyncedState([''], `games/${gameId}/path.json`, ['savePathInGame'])
+
   async function restoreGameSave(saveId: string): Promise<void> {
-    if (savePath.length === 0 && savePath[0] !== '') {
+    if (savePathInGame.length === 0 && savePathInGame[0] !== '') {
       toast.error('未找到存档路径')
       return
     }


### PR DESCRIPTION
- **修改了`path.json`的结构**
  - 移除了与存档类型相关的字段
  - 增加了`version`字段，增加了原结构json文件向新结构json文件升级的逻辑
  - 增加了`savePathInDB`字段，用于适应同时追踪多个相同名称的文件/文件夹的情形（使用数字前缀）
    > 虽然感觉几乎不会有这种情形
- **修改了属性设置界面路径栏**
  - 移除了存档类型的选项卡，同时追踪文件与文件夹
  - 添加文件夹与添加文件两个按钮同时存在，并且向存档路径输入框中增量更新
  - 增加了按钮的悬停提示文本，修改了按钮图标
  - 对于选择文件夹与选择文件窗口，将gamePath的父目录作为选择窗口的起始路径
 
#### 关于`path.json`的自动升级
目前是直接在`getDBValue`里加了一段检查版本并触发更新的逻辑，同时添加了一个`withoutchek`的参数用来关闭检查功能（因为更新逻辑的内部同样调用了`getDBValue`。

**相关issu**e：#126
