### PR TITLE
Optimized the display of the poster wall

### DIFF
--- a/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
@@ -26,10 +26,15 @@ export function BigGamePoster({
   const [gameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
   const [isAttributesDialogOpen, setIsAttributesDialogOpen] = React.useState(false)
   const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
+  const [isOpen, setIsOpen] = React.useState(false)
   return (
-    <HoverCard openDelay={250} closeDelay={100}>
+    <HoverCard open={isOpen} openDelay={250} closeDelay={100}>
       <ContextMenu>
-        <HoverCardTrigger className={cn('rounded-none')}>
+        <HoverCardTrigger
+          onMouseEnter={() => setIsOpen(true)}
+          onMouseLeave={() => setIsOpen(false)}
+          className={cn('rounded-none')}
+        >
           <ContextMenuTrigger className={cn('rounded-none')}>
             <div
               className={cn(

--- a/src/renderer/src/components/Showcase/posters/GamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/GamePoster.tsx
@@ -27,10 +27,14 @@ export function GamePoster({
   const [gameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
   const [isAttributesDialogOpen, setIsAttributesDialogOpen] = React.useState(false)
   const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
+  const [isOpen, setIsOpen] = React.useState(false)
   return (
-    <HoverCard openDelay={200} closeDelay={100}>
+    <HoverCard open={isOpen} openDelay={200} closeDelay={100}>
       <ContextMenu>
-        <HoverCardTrigger>
+        <HoverCardTrigger
+          onMouseEnter={() => setIsOpen(true)}
+          onMouseLeave={() => setIsOpen(false)}
+        >
           <ContextMenuTrigger>
             <HoverCardAnimation>
               <GameImage


### PR DESCRIPTION
### 目标问题
在海报墙的页面，鼠标移动到某个游戏上时显示的悬浮窗会遮挡住旁边的游戏，如果想显示被挡住的游戏的悬浮窗，只能把鼠标移到其他地方等待悬浮窗消失后再移动回来。