### PR TITLE
Optimized the cursor of the poster wall

### DIFF
--- a/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
@@ -125,7 +125,7 @@ export function BigGamePoster({
         side="right"
         className={cn(
           'p-0 w-[250px] h-[230px] border-0 rounded-none overflow-hidden shadow-xl relative mx-2',
-          '3xl:w-[300px] 3xl:h-[272px]'
+          '3xl:w-[300px] 3xl:h-[272px] cursor-pointer'
         )}
       >
         {/* background layer */}

--- a/src/renderer/src/components/Showcase/posters/GamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/GamePoster.tsx
@@ -113,7 +113,7 @@ export function GamePoster({
         side="right"
         className={cn(
           'p-0 w-[250px] h-[230px] border-0 rounded-none overflow-hidden shadow-xl relative mx-2',
-          '3xl:w-[300px] 3xl:h-[272px]'
+          '3xl:w-[300px] 3xl:h-[272px] cursor-pointer'
         )}
       >
         {/* background layer */}


### PR DESCRIPTION
### 问题描述
原先在悬浮窗上光标样式是默认的箭头光标，在光标由一个游戏向被悬浮窗挡住的下一个游戏移动时，会出现一次快速的样式变化，这个快速的闪烁体验有些不好。