### PR TITLE
Fixed a time zone issue in the yearly records

### DIFF
--- a/src/renderer/src/hooks/records.ts
+++ b/src/renderer/src/hooks/records.ts
@@ -279,7 +279,7 @@ export const useGameRecords = create<GameRecordsState>((set, get) => ({
     const datesArray: { date: string; playTime: number }[] = []
 
     while (current.getTime() >= lastYearDate.getTime()) {
-      const dateStr = current.toISOString().split('T')[0]
+      const dateStr = current.toLocaleDateString('en-CA')
       const playTime = Object.values(records).reduce((total, record) => {
         return total + calculateDailyPlayTime(current, record)
       }, 0)


### PR DESCRIPTION
### 问题描述
记录页面的近一年游戏时间图表，在凌晨时显示的日期标签整体前移了一天。