### PR TITLE
Resolve issue with URL input dialog flickering on update

### DIFF
--- a/src/renderer/src/components/Game/Config/AttributesDialog/Media/UrlDialog.tsx
+++ b/src/renderer/src/components/Game/Config/AttributesDialog/Media/UrlDialog.tsx
@@ -2,22 +2,20 @@ import { cn } from '~/utils'
 import { Button } from '@ui/button'
 import { Dialog, DialogContent, DialogTrigger } from '@ui/dialog'
 import { Input } from '@ui/input'
+import { useState } from 'react'
 
 export function UrlDialog({
-  mediaUrl,
-  setMediaUrl,
   setMediaWithUrl,
   isUrlDialogOpen,
   setIsUrlDialogOpen,
   type
 }: {
-  mediaUrl: string
-  setMediaUrl: (url: string) => void
-  setMediaWithUrl: (type: string) => void
+  setMediaWithUrl: (type: string, URL: string) => void
   isUrlDialogOpen: { icon: boolean; cover: boolean; background: boolean }
   setIsUrlDialogOpen: (isOpen: { icon: boolean; cover: boolean; background: boolean }) => void
   type: string
 }): JSX.Element {
+  const [mediaUrl, setMediaUrl] = useState<string>('')
   return (
     <Dialog open={isUrlDialogOpen[type]}>
       <DialogTrigger>
@@ -47,7 +45,7 @@ export function UrlDialog({
           />
           <Button
             onClick={() => {
-              setMediaWithUrl(type)
+              setMediaWithUrl(type, mediaUrl)
             }}
           >
             确定

--- a/src/renderer/src/components/Game/Config/AttributesDialog/Media/main.tsx
+++ b/src/renderer/src/components/Game/Config/AttributesDialog/Media/main.tsx
@@ -9,7 +9,6 @@ import { UrlDialog } from './UrlDialog'
 import { CropDialog } from './CropDialog'
 
 export function Media({ gameId }: { gameId: string }): JSX.Element {
-  const [mediaUrl, setMediaUrl] = useState<string>('')
   const [isUrlDialogOpen, setIsUrlDialogOpen] = useState({
     icon: false,
     cover: false,
@@ -70,19 +69,18 @@ export function Media({ gameId }: { gameId: string }): JSX.Element {
   }
 
   // Processing URL Input
-  function setMediaWithUrl(type: string): void {
+  function setMediaWithUrl(type: string, URL: string): void {
     toast.promise(
       async () => {
         setIsUrlDialogOpen({ ...isUrlDialogOpen, [type]: false })
-        if (!mediaUrl.trim()) return
-        const tempFilePath = await ipcInvoke('download-temp-image', mediaUrl)
+        if (!URL.trim()) return
+        const tempFilePath = await ipcInvoke('download-temp-image', URL)
         setCropDialogState({
           isOpen: true,
           type,
           imagePath: tempFilePath as string,
           isResizing: false
         })
-        setMediaUrl('')
       },
       {
         loading: `正在获取图片...`,
@@ -120,8 +118,6 @@ export function Media({ gameId }: { gameId: string }): JSX.Element {
         <span className={cn('icon-[mdi--file-outline] w-4 h-4')}></span>
       </Button>
       <UrlDialog
-        mediaUrl={mediaUrl}
-        setMediaUrl={setMediaUrl}
         setMediaWithUrl={setMediaWithUrl}
         isUrlDialogOpen={isUrlDialogOpen}
         setIsUrlDialogOpen={setIsUrlDialogOpen}


### PR DESCRIPTION
### 问题描述
属性-媒体-从链接获取图片的对话框，在产生内容更新时，会触发父组件的渲染，从而导致对话框闪烁（消失又出现）。