### PR TITLE
Support drag-and-drop sorting of collections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "vnite",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vnite",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "hasInstallScript": true,
       "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.5.0",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
         "@radix-ui/react-accordion": "^1.2.1",
@@ -354,6 +356,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-1.5.0.tgz",
+      "integrity": "sha512-VnHcgOBALm+mbL9CoJPI6wBNQeB0is+CkejdfAlaP8RfBoELe+0sQtE8j4Z4fPRqDzo11OEqUYKHkmx4Ttzozg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "bind-event-listener": "^3.0.0",
+        "raf-schd": "^4.0.3"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-hitbox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-hitbox/-/pragmatic-drag-and-drop-hitbox-1.0.3.tgz",
+      "integrity": "sha512-/Sbu/HqN2VGLYBhnsG7SbRNg98XKkbF6L7XDdBi+izRybfaK1FeMfodPpm/xnBHPJzwYMdkE0qtLyv6afhgMUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.1.0",
+        "@babel/runtime": "^7.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5450,6 +5473,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bind-event-listener": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+      "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
+      "license": "MIT"
+    },
     "node_modules/birpc": {
       "version": "0.2.19",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.19.tgz",
@@ -9084,9 +9113,10 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -10964,6 +10994,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "docs:preview": "vitepress preview docs"
   },
   "dependencies": {
+    "@atlaskit/pragmatic-drag-and-drop": "^1.5.0",
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
     "@radix-ui/react-accordion": "^1.2.1",

--- a/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
@@ -1,6 +1,18 @@
 import { HoverSquareCardAnimation } from '~/components/animations/HoverSquareCard'
 import { cn } from '~/utils'
 import { useNavigate } from 'react-router-dom'
+import { useEffect, useRef, useState } from 'react'
+
+import invariant from 'tiny-invariant'
+import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter'
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine'
+import {
+  attachClosestEdge,
+  type Edge,
+  extractClosestEdge
+} from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
+import { DropIndicator } from '@ui/drop-indicator'
+
 import { useCollections } from '~/hooks'
 import { CollectionCM } from '~/components/contextMenu/CollectionCM'
 import { GameImage } from '@ui/game-image'
@@ -13,68 +25,127 @@ export function CollectionPoster({
   className?: string
 }): JSX.Element {
   const navigate = useNavigate()
-  const { collections } = useCollections()
+  const { collections, reorderCollections } = useCollections()
   const collectionName = collections[collectionId].name
   const gameId = collections[collectionId].games[0]
   const length = collections[collectionId].games.length
+
+  const ref_ = useRef<HTMLDivElement>(null)
+  const [_dragging, setDragging] = useState<boolean>(false)
+  const [closestEdge, setClosestEdge] = useState<Edge | null>(null)
+
+  useEffect(() => {
+    const el = ref_.current
+    invariant(el)
+
+    return combine(
+      draggable({
+        element: el,
+        getInitialData: () => ({ collectionId }),
+        onDragStart: () => setDragging(true),
+        onDrop: () => setDragging(false)
+      }),
+      dropTargetForElements({
+        element: el,
+        getData: ({ input, element }) => {
+          // your base data you want to attach to the drop target
+          const data = {
+            id: collectionId
+          }
+          // this will 'attach' the closest edge to your `data` object
+          return attachClosestEdge(data, {
+            input,
+            element,
+            allowedEdges: ['right', 'left']
+          })
+        },
+        onDrag({ self, source }) {
+          const isSource = source.element === el
+          if (isSource) {
+            setClosestEdge(null)
+            return
+          }
+          const closestEdge = extractClosestEdge(self.data)
+          setClosestEdge(closestEdge)
+        },
+        onDragLeave() {
+          setClosestEdge(null)
+        },
+        onDrop({ self, source }) {
+          reorderCollections(
+            source.data.collectionId as string,
+            self.data.id as string,
+            extractClosestEdge(self.data) === 'left' ? 'front' : 'back'
+          )
+          setClosestEdge(null)
+        }
+      })
+    )
+  }, [])
+
   return (
     <CollectionCM collectionId={collectionId}>
-      <div
-        className={cn(
-          'group relative overflow-hidden shadow-custom-initial cursor-pointer w-[160px] h-[160px] rounded-lg',
-          'transition-all duration-300 ease-in-out',
-          'ring-0 ring-transparent',
-          'hover:ring-2 hover:ring-primary',
-          '3xl:w-[190px] 3xl:h-[190px]'
-        )}
-        onClick={() => navigate(`/library/collections/${collectionId}`)}
-      >
-        {/* background mask layer */}
-        <div
-          className={cn('absolute inset-0 bg-muted/40 backdrop-blur-sm z-10 pointer-events-none')}
-        />
-
-        {/* HoverBigCardAnimation layer */}
-
-        <div className="relative z-0">
-          <HoverSquareCardAnimation className={cn('rounded-none')}>
-            <GameImage
-              gameId={gameId}
-              type="cover"
-              alt={gameId}
-              className={cn(
-                'w-full h-full cursor-pointer object-cover',
-                '3xl:w-full 3xl:h-full',
-                className
-              )}
-              fallback={
-                <div
-                  className={cn(
-                    'w-full h-full cursor-pointer object-cover flex items-center justify-center',
-                    '3xl:w-full 3xl:h-full',
-                    className
-                  )}
-                ></div>
-              }
-            />
-          </HoverSquareCardAnimation>
-        </div>
-
-        {/* text content layer */}
+      <div className={cn('group relative')}>
         <div
           className={cn(
-            'absolute inset-0 z-20 mt-7',
-            'flex items-center justify-center',
-            'pointer-events-none'
+            'overflow-hidden shadow-custom-initial cursor-pointer w-[160px] h-[160px] rounded-lg',
+            'transition-all duration-300 ease-in-out',
+            'ring-0 ring-transparent',
+            'hover:ring-2 hover:ring-primary',
+            '3xl:w-[190px] 3xl:h-[190px]'
           )}
+          ref={ref_}
+          onClick={() => navigate(`/library/collections/${collectionId}`)}
         >
-          <div className="flex flex-col gap-1 items-center justify-center">
-            <div className={cn('text-accent-foreground text-lg font-semibold')}>
-              {collectionName}
+          {/* background mask layer */}
+          <div
+            className={cn('absolute inset-0 bg-muted/40 backdrop-blur-sm z-10 pointer-events-none')}
+          />
+
+          {/* HoverBigCardAnimation layer */}
+
+          <div className="relative z-0">
+            <HoverSquareCardAnimation className={cn('rounded-none')}>
+              <GameImage
+                gameId={gameId}
+                type="cover"
+                alt={gameId}
+                className={cn(
+                  'w-full h-full cursor-pointer object-cover',
+                  '3xl:w-full 3xl:h-full',
+                  className
+                )}
+                draggable="false"
+                fallback={
+                  <div
+                    className={cn(
+                      'w-full h-full cursor-pointer object-cover flex items-center justify-center',
+                      '3xl:w-full 3xl:h-full',
+                      className
+                    )}
+                  ></div>
+                }
+              />
+            </HoverSquareCardAnimation>
+          </div>
+
+          {/* text content layer */}
+          <div
+            className={cn(
+              'absolute inset-0 z-20 mt-7',
+              'flex items-center justify-center',
+              'pointer-events-none'
+            )}
+          >
+            <div className="flex flex-col gap-1 items-center justify-center">
+              <div className={cn('text-accent-foreground text-lg font-semibold')}>
+                {collectionName}
+              </div>
+              <div className={cn('text-accent-foreground/70')}>{`( ${length} )`}</div>
             </div>
-            <div className={cn('text-accent-foreground/70')}>{`( ${length} )`}</div>
           </div>
         </div>
+        {closestEdge && <DropIndicator edge={closestEdge} gap="24px" />}
       </div>
     </CollectionCM>
   )

--- a/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
@@ -12,10 +12,57 @@ import {
   extractClosestEdge
 } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
 import { DropIndicator } from '@ui/drop-indicator'
+import { setCustomNativeDragPreview } from '@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview'
+import { centerUnderPointer } from '@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer'
+import { createPortal } from 'react-dom'
 
 import { useCollections } from '~/hooks'
 import { CollectionCM } from '~/components/contextMenu/CollectionCM'
 import { GameImage } from '@ui/game-image'
+
+type PreviewState =
+  | {
+      type: 'idle'
+    }
+  | {
+      type: 'preview'
+      container: HTMLElement
+    }
+  | {
+      type: 'dragging'
+    }
+
+function Preview({
+  collectionName,
+  collectionLength
+}: {
+  collectionName: string
+  collectionLength: number
+}): JSX.Element {
+  return (
+    <div
+      className={cn(
+        'group relative overflow-hidden w-[160px] h-[160px] rounded-lg',
+        'transition-all duration-300 ease-in-out',
+        '3xl:w-[190px] 3xl:h-[190px]',
+        'border-4 border-dashed border-primary bg-background'
+      )}
+    >
+      <div
+        className={cn(
+          'absolute inset-0 z-20 mt-7',
+          'flex items-center justify-center',
+          'pointer-events-none'
+        )}
+      >
+        <div className="flex flex-col gap-1 items-center justify-center">
+          <div className={cn('text-accent-foreground text-lg font-semibold')}>{collectionName}</div>
+          <div className={cn('text-accent-foreground/70')}>{`( ${collectionLength} )`}</div>
+        </div>
+      </div>
+    </div>
+  )
+}
 
 export function CollectionPoster({
   collectionId,
@@ -31,8 +78,9 @@ export function CollectionPoster({
   const length = collections[collectionId].games.length
 
   const ref_ = useRef<HTMLDivElement>(null)
-  const [_dragging, setDragging] = useState<boolean>(false)
   const [closestEdge, setClosestEdge] = useState<Edge | null>(null)
+  const [dragging, setDragging] = useState<boolean>(false)
+  const [previewState, setPreviewState] = useState<PreviewState>({ type: 'idle' })
 
   useEffect(() => {
     const el = ref_.current
@@ -41,6 +89,19 @@ export function CollectionPoster({
     return combine(
       draggable({
         element: el,
+        onGenerateDragPreview({ nativeSetDragImage }) {
+          setCustomNativeDragPreview({
+            getOffset: (container) => {
+              const half = centerUnderPointer(container)
+              return { x: (half.x * 4) / 3, y: (half.y * 4) / 3 }
+            },
+            render({ container }) {
+              setPreviewState({ type: 'preview', container })
+              return (): void => setPreviewState({ type: 'idle' })
+            },
+            nativeSetDragImage
+          })
+        },
         getInitialData: () => ({ collectionId }),
         onDragStart: () => setDragging(true),
         onDrop: () => setDragging(false)
@@ -85,67 +146,79 @@ export function CollectionPoster({
 
   return (
     <CollectionCM collectionId={collectionId}>
-      <div className={cn('group relative')}>
-        <div
-          className={cn(
-            'overflow-hidden shadow-custom-initial cursor-pointer w-[160px] h-[160px] rounded-lg',
-            'transition-all duration-300 ease-in-out',
-            'ring-0 ring-transparent',
-            'hover:ring-2 hover:ring-primary',
-            '3xl:w-[190px] 3xl:h-[190px]'
-          )}
-          ref={ref_}
-          onClick={() => navigate(`/library/collections/${collectionId}`)}
-        >
-          {/* background mask layer */}
-          <div
-            className={cn('absolute inset-0 bg-muted/40 backdrop-blur-sm z-10 pointer-events-none')}
-          />
-
-          {/* HoverBigCardAnimation layer */}
-
-          <div className="relative z-0">
-            <HoverSquareCardAnimation className={cn('rounded-none')}>
-              <GameImage
-                gameId={gameId}
-                type="cover"
-                alt={gameId}
-                className={cn(
-                  'w-full h-full cursor-pointer object-cover',
-                  '3xl:w-full 3xl:h-full',
-                  className
-                )}
-                draggable="false"
-                fallback={
-                  <div
-                    className={cn(
-                      'w-full h-full cursor-pointer object-cover flex items-center justify-center',
-                      '3xl:w-full 3xl:h-full',
-                      className
-                    )}
-                  ></div>
-                }
-              />
-            </HoverSquareCardAnimation>
-          </div>
-
-          {/* text content layer */}
+      <div className={cn('group relative')} ref={ref_}>
+        {dragging ? (
+          <Preview collectionLength={length} collectionName={collectionName}/>
+        ) : (
           <div
             className={cn(
-              'absolute inset-0 z-20 mt-7',
-              'flex items-center justify-center',
-              'pointer-events-none'
+              'overflow-hidden shadow-custom-initial cursor-pointer w-[160px] h-[160px] rounded-lg',
+              'transition-all duration-300 ease-in-out',
+              'ring-0 ring-transparent',
+              'hover:ring-2 hover:ring-primary',
+              '3xl:w-[190px] 3xl:h-[190px]'
             )}
+            onClick={() => navigate(`/library/collections/${collectionId}`)}
           >
-            <div className="flex flex-col gap-1 items-center justify-center">
-              <div className={cn('text-accent-foreground text-lg font-semibold')}>
-                {collectionName}
+            {/* background mask layer */}
+            <div
+              className={cn(
+                'absolute inset-0 bg-muted/40 backdrop-blur-sm z-10 pointer-events-none'
+              )}
+            />
+
+            {/* HoverBigCardAnimation layer */}
+
+            <div className="relative z-0">
+              <HoverSquareCardAnimation className={cn('rounded-none')}>
+                <GameImage
+                  gameId={gameId}
+                  type="cover"
+                  alt={gameId}
+                  className={cn(
+                    'w-full h-full cursor-pointer object-cover',
+                    '3xl:w-full 3xl:h-full',
+                    className
+                  )}
+                  draggable="false"
+                  fallback={
+                    <div
+                      className={cn(
+                        'w-full h-full cursor-pointer object-cover flex items-center justify-center',
+                        '3xl:w-full 3xl:h-full',
+                        className
+                      )}
+                    ></div>
+                  }
+                />
+              </HoverSquareCardAnimation>
+            </div>
+
+            {/* text content layer */}
+            <div
+              className={cn(
+                'absolute inset-0 z-20 mt-7',
+                'flex items-center justify-center',
+                'pointer-events-none'
+              )}
+            >
+              <div className="flex flex-col gap-1 items-center justify-center">
+                <div className={cn('text-accent-foreground text-lg font-semibold')}>
+                  {collectionName}
+                </div>
+                <div className={cn('text-accent-foreground/70')}>{`( ${length} )`}</div>
               </div>
-              <div className={cn('text-accent-foreground/70')}>{`( ${length} )`}</div>
             </div>
           </div>
-        </div>
+        )}
+
         {closestEdge && <DropIndicator edge={closestEdge} gap="24px" />}
+        {previewState.type === 'preview'
+          ? createPortal(
+              <Preview collectionLength={length} collectionName={collectionName} />,
+              previewState.container
+            )
+          : null}
       </div>
     </CollectionCM>
   )

--- a/src/renderer/src/components/ui/drop-indicator.tsx
+++ b/src/renderer/src/components/ui/drop-indicator.tsx
@@ -1,0 +1,55 @@
+// Modified from https://github.com/alexreardon/pdnd-react-tailwind/blob/main/src/drop-indicator.tsx
+import type { Edge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/types'
+import type { CSSProperties, HTMLAttributes } from 'react'
+
+type Orientation = 'horizontal' | 'vertical'
+
+const edgeToOrientationMap: Record<Edge, Orientation> = {
+  top: 'horizontal',
+  bottom: 'horizontal',
+  left: 'vertical',
+  right: 'vertical'
+}
+
+const orientationStyles: Record<Orientation, HTMLAttributes<HTMLElement>['className']> = {
+  horizontal:
+    'h-[--line-thickness] left-[--terminal-radius] right-0 before:left-[--negative-terminal-size]',
+  vertical:
+    'w-[--line-thickness] top-[--terminal-radius] bottom-0 before:top-[--negative-terminal-size]'
+}
+
+const edgeStyles: Record<Edge, HTMLAttributes<HTMLElement>['className']> = {
+  top: 'top-[--line-offset] before:top-[--offset-terminal]',
+  right: 'right-[--line-offset] before:right-[--offset-terminal]',
+  bottom: 'bottom-[--line-offset] before:bottom-[--offset-terminal]',
+  left: 'left-[--line-offset] before:left-[--offset-terminal]'
+}
+
+const strokeSize = 4
+const terminalSize = 8
+const offsetToAlignTerminalWithLine = (strokeSize - terminalSize) / 2
+
+/**
+ * This is a tailwind port of `@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box`
+ */
+export function DropIndicator({ edge, gap }: { edge: Edge; gap: string }): JSX.Element {
+  const lineOffset = `calc(-0.5 * (${gap} + ${strokeSize}px))`
+
+  const orientation = edgeToOrientationMap[edge]
+
+  return (
+    <div
+      style={
+        {
+          '--line-thickness': `${strokeSize}px`,
+          '--line-offset': `${lineOffset}`,
+          '--terminal-size': `${terminalSize}px`,
+          '--terminal-radius': `${terminalSize / 2}px`,
+          '--negative-terminal-size': `-${terminalSize}px`,
+          '--offset-terminal': `${offsetToAlignTerminalWithLine}px`
+        } as CSSProperties
+      }
+      className={`absolute z-10 bg-blue-700 pointer-events-none before:content-[''] before:w-[--terminal-size] before:h-[--terminal-size] box-border before:absolute before:border-[length:--line-thickness] before:border-solid before:border-blue-700 before:rounded-full ${orientationStyles[orientation]} ${[edgeStyles[edge]]}`}
+    ></div>
+  )
+}


### PR DESCRIPTION
### 功能
- 引入了`Pragmatic drag and drop`用于支持拖拽相关功能
- 实现了在主页通过拖动收藏夹图标进行重新排序的功能

### 测试时发现的一些问题
- 正式版本中，主页的收藏夹栏的左右滚动条并没有作用（图1），因此不确定这种拖拽对于左右滚动条的适应性如何
- 宽封面时的收藏夹图片存在黑边（同图1）


![Snipaste_2025-02-06_13-18-39](https://github.com/user-attachments/assets/5df1053b-5b5b-4263-affd-b7cab46126eb)
