### PR TITLE
Optimize the text selection on the game overview page

### DIFF
--- a/src/renderer/src/components/Game/Header.tsx
+++ b/src/renderer/src/components/Game/Header.tsx
@@ -1,7 +1,9 @@
-import { cn } from '~/utils'
-import { useDBSyncedState } from '~/hooks'
 import { Button } from '@ui/button'
+import { useDBSyncedState } from '~/hooks'
+import { cn } from '~/utils'
 // import { Badge } from '@ui/badge'
+import { Dialog, DialogContent, DialogTrigger } from '@ui/dialog'
+import { Input } from '@ui/input'
 import {
   Select,
   SelectContent,
@@ -10,15 +12,13 @@ import {
   SelectLabel,
   SelectTrigger
 } from '@ui/select'
-import { Dialog, DialogContent, DialogTrigger } from '@ui/dialog'
-import { Input } from '@ui/input'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { useRunningGames } from '~/pages/Library/store'
 import { Config } from './Config'
+import { Record } from './Overview/Record'
 import { StartGame } from './StartGame'
 import { StopGame } from './StopGame'
-import { Record } from './Overview/Record'
-import { toast } from 'sonner'
-import { useState } from 'react'
-import { useRunningGames } from '~/pages/Library/store'
 
 export function Header({
   gameId,
@@ -92,6 +92,17 @@ export function Header({
     toast.success('评分已保存')
   }
 
+  const handleCopy = (text: string): void => {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        toast.success('已复制到剪切板', { duration: 1000 })
+      })
+      .catch((error) => {
+        toast.error(`复制文本到剪切板失败: ${error}`)
+      })
+  }
+
   return (
     <div
       className={cn(
@@ -118,14 +129,33 @@ export function Header({
           showOriginalNameInGameHeader && originalName && originalName !== name && 'items-end'
         )}
       >
-        <div className={cn('truncate')}>
-          <span className={cn('font-bold text-2xl text-accent-foreground')}>{name}</span>
+        <div className={cn('select-none truncate z-10')}>
+          <span
+            className={cn('font-bold text-2xl text-accent-foreground cursor-pointer')}
+            onClick={() => {
+              handleCopy(name)
+            }}
+          >
+            {name}
+          </span>
           {showOriginalNameInGameHeader && originalName && originalName !== name && (
-            <span className={cn('font-bold text-accent-foreground ml-3')}>{originalName}</span>
+            <span
+              className={cn('font-bold text-accent-foreground ml-3 cursor-pointer')}
+              onClick={() => {
+                handleCopy(originalName)
+              }}
+            >
+              {originalName}
+            </span>
           )}
         </div>
         {isSticky && (
-          <div className={cn('flex flex-row gap-3 items-center duration-300 z-20', '3xl:gap-5')}>
+          <div
+            className={cn(
+              'flex flex-row gap-3 items-center duration-300 z-20 select-none',
+              '3xl:gap-5'
+            )}
+          >
             {runningGames.includes(gameId) ? (
               <StopGame gameId={gameId} className={cn('')} />
             ) : (
@@ -184,7 +214,12 @@ export function Header({
         )}
       </div>
       {!isSticky && (
-        <div className={cn('flex flex-row justify-between items-center duration-300', '3xl:gap-5')}>
+        <div
+          className={cn(
+            'flex flex-row justify-between items-center duration-300 select-none',
+            '3xl:gap-5'
+          )}
+        >
           <Record gameId={gameId} />
           <div className={cn('flex flex-row gap-3 items-center z-20', '3xl:gap-5')}>
             {runningGames.includes(gameId) ? (

--- a/src/renderer/src/components/Game/Overview/Information/InformationCard.tsx
+++ b/src/renderer/src/components/Game/Overview/Information/InformationCard.tsx
@@ -1,9 +1,9 @@
 import { Separator } from '@ui/separator'
-import { cn } from '~/utils'
-import { useDBSyncedState } from '~/hooks'
-import { InformationDialog } from './InformationDialog'
-import { FilterAdder } from '../../FilterAdder'
 import React from 'react'
+import { useDBSyncedState } from '~/hooks'
+import { cn } from '~/utils'
+import { FilterAdder } from '../../FilterAdder'
+import { InformationDialog } from './InformationDialog'
 
 export function InformationCard({
   gameId,
@@ -13,6 +13,7 @@ export function InformationCard({
   className?: string
 }): JSX.Element {
   const [originalName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['originalName'])
+  const [name] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
   const [developers] = useDBSyncedState([''], `games/${gameId}/metadata.json`, ['developers'])
   const [publishers] = useDBSyncedState([''], `games/${gameId}/metadata.json`, ['publishers'])
   const [releaseDate] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['releaseDate'])
@@ -22,7 +23,7 @@ export function InformationCard({
   return (
     <div className={cn(className, 'group')}>
       <div className={cn('flex flex-row justify-between items-center')}>
-        <div className={cn('font-bold')}>基本信息</div>
+        <div className={cn('font-bold select-none')}>基本信息</div>
         <InformationDialog gameId={gameId} />
       </div>
 
@@ -30,11 +31,15 @@ export function InformationCard({
 
       <div className={cn('grid grid-cols-[60px_1fr] gap-x-3 gap-y-2 text-sm')}>
         {/* original name */}
-        <div className={cn('whitespace-nowrap')}>原名</div>
+        <div className={cn('whitespace-nowrap select-none')}>原名</div>
         <div>{originalName === '' ? '暂无' : originalName}</div>
 
+        {/* name */}
+        <div className={cn('whitespace-nowrap select-none')}>译名</div>
+        <div>{name === originalName || name === '' ? '暂无' : name}</div>
+
         {/* developers */}
-        <div className={cn('whitespace-nowrap')}>开发商</div>
+        <div className={cn('whitespace-nowrap select-none')}>开发商</div>
         <div
           className={cn(
             'flex flex-wrap gap-x-1 gap-y-[6px]',
@@ -51,7 +56,7 @@ export function InformationCard({
         </div>
 
         {/* publishers */}
-        <div className={cn('whitespace-nowrap')}>发行商</div>
+        <div className={cn('whitespace-nowrap select-none')}>发行商</div>
         <div
           className={cn(
             'flex flex-wrap gap-x-1 gap-y-1',
@@ -68,7 +73,7 @@ export function InformationCard({
         </div>
 
         {/* releaseDate */}
-        <div className={cn('whitespace-nowrap')}>发行日期</div>
+        <div className={cn('whitespace-nowrap select-none')}>发行日期</div>
         <div className={cn('flex flex-wrap gap-x-1 gap-y-1', releaseDate !== '' && 'mt-[2px]')}>
           {releaseDate === '' ? (
             '暂无'
@@ -82,7 +87,7 @@ export function InformationCard({
         </div>
 
         {/* platforms */}
-        <div className={cn('whitespace-nowrap')}>平台</div>
+        <div className={cn('whitespace-nowrap select-none')}>平台</div>
         <div
           className={cn('flex flex-wrap gap-x-1 gap-y-1', platforms.join(',') !== '' && 'mt-[2px]')}
         >
@@ -96,7 +101,7 @@ export function InformationCard({
         </div>
 
         {/* genres */}
-        <div className={cn('whitespace-nowrap')}>类型</div>
+        <div className={cn('whitespace-nowrap select-none')}>类型</div>
         <div
           className={cn('flex flex-wrap gap-x-1 gap-y-1', genres.join(',') !== '' && 'mt-[2px]')}
         >

--- a/src/renderer/src/components/Game/Overview/Information/InformationCard.tsx
+++ b/src/renderer/src/components/Game/Overview/Information/InformationCard.tsx
@@ -1,5 +1,6 @@
 import { Separator } from '@ui/separator'
 import React from 'react'
+import { toast } from 'sonner'
 import { useDBSyncedState } from '~/hooks'
 import { cn } from '~/utils'
 import { FilterAdder } from '../../FilterAdder'
@@ -20,10 +21,44 @@ export function InformationCard({
   const [genres] = useDBSyncedState([''], `games/${gameId}/metadata.json`, ['genres'])
   const [platforms] = useDBSyncedState([''], `games/${gameId}/metadata.json`, ['platforms'])
 
+  const handleCopy = (): void => {
+    const titles = {
+      originalName: '原名',
+      name: '译名',
+      developers: '开发商',
+      publishers: '发行商',
+      releaseDate: '发行日期',
+      platforms: '平台',
+      genres: '类型'
+    }
+    navigator.clipboard
+      .writeText(
+        `${Object.entries({
+          originalName,
+          name,
+          developers,
+          publishers,
+          releaseDate,
+          genres,
+          platforms
+        })
+          .map(([key, value]) => `${titles[key]}: ${value}`)
+          .join('\n')}`
+      )
+      .then(() => {
+        toast.success('已复制到剪切板', { duration: 1000 })
+      })
+      .catch((error) => {
+        toast.error(`复制文本到剪切板失败: ${error}`)
+      })
+  }
+
   return (
     <div className={cn(className, 'group')}>
       <div className={cn('flex flex-row justify-between items-center')}>
-        <div className={cn('font-bold select-none')}>基本信息</div>
+        <div className={cn('font-bold select-none cursor-pointer')} onClick={handleCopy}>
+          基本信息
+        </div>
         <InformationDialog gameId={gameId} />
       </div>
 

--- a/src/renderer/src/components/Game/Overview/Information/InformationDialog.tsx
+++ b/src/renderer/src/components/Game/Overview/Information/InformationDialog.tsx
@@ -1,15 +1,16 @@
+import { ArrayInput } from '@ui/array-input'
+import { DateInput } from '@ui/date-input'
 import { Dialog, DialogContent, DialogTrigger } from '@ui/dialog'
 import { Input } from '@ui/input'
-import { DateInput } from '@ui/date-input'
-import { TooltipContent, TooltipTrigger, Tooltip } from '@ui/tooltip'
-import { ArrayInput } from '@ui/array-input'
-import { cn } from '~/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@ui/tooltip'
 import { useDBSyncedState } from '~/hooks'
+import { cn } from '~/utils'
 
 export function InformationDialog({ gameId }: { gameId: string }): JSX.Element {
   const [originalName, setOriginalName] = useDBSyncedState('', `games/${gameId}/metadata.json`, [
     'originalName'
   ])
+  const [name, setName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
   const [developers, setDevelopers] = useDBSyncedState([''], `games/${gameId}/metadata.json`, [
     'developers'
   ])
@@ -33,7 +34,7 @@ export function InformationDialog({ gameId }: { gameId: string }): JSX.Element {
       <DialogContent className={cn('flex flex-col gap-5')}>
         <div className={cn('flex flex-col gap-3 p-4')}>
           <div className={cn('flex flex-row gap-3 items-center justify-center')}>
-            <div className={cn('grow whitespace-nowrap')}>原名</div>
+            <div className={cn('grow whitespace-nowrap select-none')}>原名</div>
             <Input
               value={originalName}
               onChange={(e) => setOriginalName(e.target.value)}
@@ -42,7 +43,16 @@ export function InformationDialog({ gameId }: { gameId: string }): JSX.Element {
             />
           </div>
           <div className={cn('flex flex-row gap-3 items-center justify-center')}>
-            <div className={cn('grow whitespace-nowrap')}>开发商</div>
+            <div className={cn('grow whitespace-nowrap select-none')}>译名</div>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="暂无译名"
+              className={cn(' text-sm')}
+            />
+          </div>
+          <div className={cn('flex flex-row gap-3 items-center justify-center')}>
+            <div className={cn('grow whitespace-nowrap select-none')}>开发商</div>
             <Tooltip>
               <TooltipTrigger className={cn('p-0 max-w-none m-0 w-full')}>
                 <ArrayInput value={developers} onChange={setDevelopers} placeholder="暂无开发商" />
@@ -53,7 +63,7 @@ export function InformationDialog({ gameId }: { gameId: string }): JSX.Element {
             </Tooltip>
           </div>
           <div className={cn('flex flex-row gap-3 items-center justify-center')}>
-            <div className={cn('grow whitespace-nowrap')}>发行商</div>
+            <div className={cn('grow whitespace-nowrap select-none')}>发行商</div>
             <Tooltip>
               <TooltipTrigger className={cn('p-0 max-w-none m-0 w-full')}>
                 <ArrayInput value={publishers} onChange={setPublishers} placeholder="暂无发行商" />
@@ -64,7 +74,7 @@ export function InformationDialog({ gameId }: { gameId: string }): JSX.Element {
             </Tooltip>
           </div>
           <div className={cn('flex flex-row gap-3 items-center justify-start')}>
-            <div className={cn('whitespace-nowrap')}>发行日期</div>
+            <div className={cn('whitespace-nowrap select-none')}>发行日期</div>
             <DateInput
               value={releaseDate}
               onChange={(e) => setReleaseDate(e.target.value)}
@@ -73,7 +83,7 @@ export function InformationDialog({ gameId }: { gameId: string }): JSX.Element {
             />
           </div>
           <div className={cn('flex flex-row gap-3 items-center justify-center')}>
-            <div className={cn('grow whitespace-nowrap')}>平台</div>
+            <div className={cn('grow whitespace-nowrap select-none')}>平台</div>
             <Tooltip>
               <TooltipTrigger className={cn('p-0 max-w-none m-0 w-full')}>
                 <ArrayInput value={platforms} onChange={setPlatforms} placeholder="暂无平台" />
@@ -84,7 +94,7 @@ export function InformationDialog({ gameId }: { gameId: string }): JSX.Element {
             </Tooltip>
           </div>
           <div className={cn('flex flex-row gap-3 items-center justify-center')}>
-            <div className={cn('whitespace-nowrap')}>类型</div>
+            <div className={cn('whitespace-nowrap select-none')}>类型</div>
             <Tooltip>
               <TooltipTrigger className={cn('p-0 max-w-none m-0 w-full')}>
                 <ArrayInput value={genres} onChange={setGenres} placeholder="暂无类型" />

--- a/src/renderer/src/components/Game/Overview/RelatedSites/RelatedSitesCard.tsx
+++ b/src/renderer/src/components/Game/Overview/RelatedSites/RelatedSitesCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@ui/link'
 import { Separator } from '@ui/separator'
 import { isEqual } from 'lodash'
+import { toast } from 'sonner'
 import { useDBSyncedState } from '~/hooks'
 import { cn } from '~/utils'
 import { RelatedSitesDialog } from './RelatedSitesDialog'
@@ -17,10 +18,23 @@ export function RelatedSitesCard({
     `games/${gameId}/metadata.json`,
     ['relatedSites']
   )
+
+  const handleCopy = (): void => {
+    navigator.clipboard
+      .writeText(relatedSites.map((item) => `${item.label}: ${item.url}`).join('\n'))
+      .then(() => {
+        toast.success('已复制到剪切板', { duration: 1000 })
+      })
+      .catch((error) => {
+        toast.error(`复制文本到剪切板失败: ${error}`)
+      })
+  }
   return (
     <div className={cn(className, 'group')}>
       <div className={cn('flex flex-row justify-between items-center')}>
-        <div className={cn('font-bold select-none')}>相关网站</div>
+        <div className={cn('font-bold select-none cursor-pointer')} onClick={handleCopy}>
+          相关网站
+        </div>
         <RelatedSitesDialog gameId={gameId} />
       </div>
       <Separator className={cn('my-3 bg-primary')} />

--- a/src/renderer/src/components/Game/Overview/RelatedSites/RelatedSitesCard.tsx
+++ b/src/renderer/src/components/Game/Overview/RelatedSites/RelatedSitesCard.tsx
@@ -1,9 +1,9 @@
-import { cn } from '~/utils'
 import { Link } from '@ui/link'
 import { Separator } from '@ui/separator'
-import { useDBSyncedState } from '~/hooks'
-import { RelatedSitesDialog } from './RelatedSitesDialog'
 import { isEqual } from 'lodash'
+import { useDBSyncedState } from '~/hooks'
+import { cn } from '~/utils'
+import { RelatedSitesDialog } from './RelatedSitesDialog'
 
 export function RelatedSitesCard({
   gameId,
@@ -20,7 +20,7 @@ export function RelatedSitesCard({
   return (
     <div className={cn(className, 'group')}>
       <div className={cn('flex flex-row justify-between items-center')}>
-        <div className={cn('font-bold')}>相关网站</div>
+        <div className={cn('font-bold select-none')}>相关网站</div>
         <RelatedSitesDialog gameId={gameId} />
       </div>
       <Separator className={cn('my-3 bg-primary')} />

--- a/src/renderer/src/components/Game/Overview/Tags/TagsCard.tsx
+++ b/src/renderer/src/components/Game/Overview/Tags/TagsCard.tsx
@@ -1,5 +1,6 @@
 import { Separator } from '@ui/separator'
 import React from 'react'
+import { toast } from 'sonner'
 import { useDBSyncedState } from '~/hooks'
 import { cn } from '~/utils'
 import { FilterAdder } from '../../FilterAdder'
@@ -13,10 +14,22 @@ export function TagsCard({
   className?: string
 }): JSX.Element {
   const [tags] = useDBSyncedState([''], `games/${gameId}/metadata.json`, ['tags'])
+  const handleCopy = (): void => {
+    navigator.clipboard
+      .writeText(`${tags}`)
+      .then(() => {
+        toast.success('已复制到剪切板', { duration: 1000 })
+      })
+      .catch((error) => {
+        toast.error(`复制文本到剪切板失败: ${error}`)
+      })
+  }
   return (
     <div className={cn(className, 'group')}>
-      <div className={cn('flex flex-row justify-between items-center select-none')}>
-        <div>标签</div>
+      <div className={cn('flex flex-row justify-between items-center')}>
+        <div className={cn('select-none cursor-pointer')} onClick={handleCopy}>
+          标签
+        </div>
         <TagsDialog gameId={gameId} />
       </div>
       <Separator className={cn('my-3 bg-primary')} />

--- a/src/renderer/src/components/Game/Overview/Tags/TagsCard.tsx
+++ b/src/renderer/src/components/Game/Overview/Tags/TagsCard.tsx
@@ -1,9 +1,9 @@
-import { cn } from '~/utils'
-import { useDBSyncedState } from '~/hooks'
 import { Separator } from '@ui/separator'
-import { TagsDialog } from './TagsDialog'
-import { FilterAdder } from '../../FilterAdder'
 import React from 'react'
+import { useDBSyncedState } from '~/hooks'
+import { cn } from '~/utils'
+import { FilterAdder } from '../../FilterAdder'
+import { TagsDialog } from './TagsDialog'
 
 export function TagsCard({
   gameId,
@@ -15,7 +15,7 @@ export function TagsCard({
   const [tags] = useDBSyncedState([''], `games/${gameId}/metadata.json`, ['tags'])
   return (
     <div className={cn(className, 'group')}>
-      <div className={cn('flex flex-row justify-between items-center')}>
+      <div className={cn('flex flex-row justify-between items-center select-none')}>
         <div>标签</div>
         <TagsDialog gameId={gameId} />
       </div>

--- a/src/renderer/src/components/Game/Overview/description/DescriptionCard.tsx
+++ b/src/renderer/src/components/Game/Overview/description/DescriptionCard.tsx
@@ -1,8 +1,8 @@
 import { Separator } from '@ui/separator'
-import { DescriptionDialog } from './DescriptionDialog'
-import { cn, HTMLParserOptions } from '~/utils'
-import { useDBSyncedState } from '~/hooks'
 import parse from 'html-react-parser'
+import { useDBSyncedState } from '~/hooks'
+import { cn, HTMLParserOptions } from '~/utils'
+import { DescriptionDialog } from './DescriptionDialog'
 
 export function DescriptionCard({
   gameId,
@@ -15,7 +15,7 @@ export function DescriptionCard({
   return (
     <div className={cn('bg-transparent border-0 shadow-none', className, 'group')}>
       <div className={cn('flex flex-row justify-between items-center')}>
-        <div className={cn('font-bold')}>简介</div>
+        <div className={cn('font-bold select-none')}>简介</div>
         <DescriptionDialog gameId={gameId} />
       </div>
       <Separator className={cn('my-3 bg-primary')} />

--- a/src/renderer/src/components/Game/Overview/description/DescriptionCard.tsx
+++ b/src/renderer/src/components/Game/Overview/description/DescriptionCard.tsx
@@ -1,5 +1,6 @@
 import { Separator } from '@ui/separator'
 import parse from 'html-react-parser'
+import { toast } from 'sonner'
 import { useDBSyncedState } from '~/hooks'
 import { cn, HTMLParserOptions } from '~/utils'
 import { DescriptionDialog } from './DescriptionDialog'
@@ -12,10 +13,23 @@ export function DescriptionCard({
   className?: string
 }): JSX.Element {
   const [description] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['description'])
+
+  const handleCopy = (): void => {
+    navigator.clipboard
+      .writeText(description)
+      .then(() => {
+        toast.success('已复制到剪切板', { duration: 1000 })
+      })
+      .catch((error) => {
+        toast.error(`复制文本到剪切板失败: ${error}`)
+      })
+  }
   return (
     <div className={cn('bg-transparent border-0 shadow-none', className, 'group')}>
       <div className={cn('flex flex-row justify-between items-center')}>
-        <div className={cn('font-bold select-none')}>简介</div>
+        <div className={cn('font-bold select-none cursor-pointer')} onClick={handleCopy}>
+          简介
+        </div>
         <DescriptionDialog gameId={gameId} />
       </div>
       <Separator className={cn('my-3 bg-primary')} />


### PR DESCRIPTION
主要对游戏详情页做了一些优化：
- 增加了点击游戏名、简介、基本信息、相关站点、标签后，自动将其复制到剪切板的功能
- 在基本信息栏中加入了“译名”一项
- 阻止了若干不必要的文本选取