### PR TITLE
Optimize the highlighting of the game list

### DIFF
--- a/src/renderer/src/components/Config/Appearances.tsx
+++ b/src/renderer/src/components/Config/Appearances.tsx
@@ -1,7 +1,7 @@
-import { cn } from '~/utils'
 import { Card, CardContent, CardHeader, CardTitle } from '@ui/card'
 import { Switch } from '@ui/switch'
 import { useDBSyncedState } from '~/hooks'
+import { cn } from '~/utils'
 
 export function Appearances(): JSX.Element {
   const [showRecentGamesInGameList, setShowRecentGamesInGameList] = useDBSyncedState(
@@ -23,6 +23,11 @@ export function Appearances(): JSX.Element {
     'others',
     'gameList',
     'highlightLocalGames'
+  ])
+  const [markLocalGames, setMarkLocalGames] = useDBSyncedState(true, 'config.json', [
+    'others',
+    'gameList',
+    'markLocalGames'
   ])
   return (
     <Card className={cn('group')}>
@@ -61,6 +66,13 @@ export function Appearances(): JSX.Element {
             <Switch
               checked={highlightLocalGames}
               onCheckedChange={(checked) => setHighlightLocalGames(checked)}
+            />
+          </div>
+          <div className={cn('flex flex-row justify-between items-center')}>
+            <div>是否在游戏列表中标记本地游戏</div>
+            <Switch
+              checked={markLocalGames}
+              onCheckedChange={(checked) => setMarkLocalGames(checked)}
             />
           </div>
         </div>

--- a/src/renderer/src/components/Librarybar/GameNav.tsx
+++ b/src/renderer/src/components/Librarybar/GameNav.tsx
@@ -1,15 +1,15 @@
-import { Nav } from '../ui/nav'
-import { cn } from '~/utils'
-import { useDBSyncedState } from '~/hooks'
-import { GameNavCM } from '../contextMenu/GameNavCM'
 import { ContextMenu, ContextMenuTrigger } from '@ui/context-menu'
 import { GameImage } from '@ui/game-image'
-import { AttributesDialog } from '../Game/Config/AttributesDialog'
+import { Nav } from '@ui/nav'
 import React from 'react'
-import { AddCollectionDialog } from '../dialog/AddCollectionDialog'
-import { useGameBatchEditorStore } from '../GameBatchEditor/store'
-import { BatchGameNavCM } from '../GameBatchEditor/BatchGameNavCM'
 import { useLocation } from 'react-router-dom'
+import { useDBSyncedState } from '~/hooks'
+import { cn } from '~/utils'
+import { GameNavCM } from '../contextMenu/GameNavCM'
+import { AddCollectionDialog } from '../dialog/AddCollectionDialog'
+import { AttributesDialog } from '../Game/Config/AttributesDialog'
+import { BatchGameNavCM } from '../GameBatchEditor/BatchGameNavCM'
+import { useGameBatchEditorStore } from '../GameBatchEditor/store'
 
 export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }): JSX.Element {
   const location = useLocation()
@@ -20,10 +20,17 @@ export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }
     'gameList',
     'highlightLocalGames'
   ])
+  const [markLocalGames] = useDBSyncedState(true, 'config.json', [
+    'others',
+    'gameList',
+    'markLocalGames'
+  ])
   const [isAttributesDialogOpen, setIsAttributesDialogOpen] = React.useState(false)
   const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
   const { addGameId, removeGameId, clearGameIds, gameIds, lastSelectedId, setLastSelectedId } =
     useGameBatchEditorStore()
+
+  const isLocated = location.pathname.includes(`/games/${gameId}`)
 
   // Check if the current game is selected
   const isSelected = gameIds.includes(gameId)
@@ -95,14 +102,16 @@ export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }
           <div onClick={handleGameClick} data-game-id={gameId}>
             <Nav
               variant="sidebar"
-              className={cn(
-                'text-xs p-3 h-5 rounded-none',
-                highlightLocalGames && gamePath && 'text-accent-foreground',
-                isSelected && isBatchMode && 'bg-accent text-accent-foreground'
-              )}
+              className={cn('text-xs p-3 h-5 rounded-none', {
+                'text-accent-foreground':
+                  (highlightLocalGames && gamePath) ||
+                  (!highlightLocalGames && isSelected && isBatchMode) ||
+                  (!highlightLocalGames && isLocated),
+                'bg-accent': (isSelected && isBatchMode) || isLocated
+              })}
               to={`./games/${gameId}/${groupId}`}
             >
-              <div className={cn('flex flex-row gap-2 items-center')}>
+              <div className={cn('flex flex-row gap-2 items-center w-full')}>
                 <div className={cn('flex items-center')}>
                   <GameImage
                     gameId={gameId}
@@ -114,7 +123,14 @@ export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }
                     }
                   />
                 </div>
-                <div className={cn('truncate')}>{gameName}</div>
+                <div className={cn('truncate flex-grow')}>{gameName}</div>
+                {markLocalGames && gamePath && (
+                  <span
+                    className={cn(
+                      'icon-[mdi--check-outline] w-[10px] h-[10px] mr-[-10px] flex-shrink-0'
+                    )}
+                  ></span>
+                )}
               </div>
             </Nav>
           </div>

--- a/src/renderer/src/components/Librarybar/GameNav.tsx
+++ b/src/renderer/src/components/Librarybar/GameNav.tsx
@@ -101,12 +101,13 @@ export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }
         <ContextMenuTrigger>
           <div onClick={handleGameClick} data-game-id={gameId}>
             <Nav
-              variant="sidebar"
+              variant="gameList"
               className={cn('text-xs p-3 h-5 rounded-none', {
                 'text-accent-foreground':
                   (highlightLocalGames && gamePath) ||
                   (!highlightLocalGames && isSelected && isBatchMode) ||
                   (!highlightLocalGames && isLocated),
+                'hover:text-accent-foreground': !highlightLocalGames,
                 'bg-accent': (isSelected && isBatchMode) || isLocated
               })}
               to={`./games/${gameId}/${groupId}`}

--- a/src/renderer/src/components/Librarybar/main.tsx
+++ b/src/renderer/src/components/Librarybar/main.tsx
@@ -1,8 +1,6 @@
-import { cn } from '~/utils'
-import { Nav } from '@ui/nav'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@ui/tooltip'
-import { Input } from '@ui/input'
 import { Button } from '@ui/button'
+import { Input } from '@ui/input'
+import { Nav } from '@ui/nav'
 import {
   Select,
   SelectContent,
@@ -12,15 +10,17 @@ import {
   SelectTrigger,
   SelectValue
 } from '@ui/select'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@ui/tooltip'
+import { isEqual } from 'lodash'
+import { useEffect, useRef, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { create } from 'zustand'
 import { useDBSyncedState } from '~/hooks'
-import { GameList } from './GameList'
+import { cn } from '~/utils'
+import { useGameBatchEditorStore } from '../GameBatchEditor/store'
 import { Filter } from './Filter'
 import { useFilterStore } from './Filter/store'
-import { isEqual } from 'lodash'
-import { create } from 'zustand'
-import { useLocation } from 'react-router-dom'
-import { useEffect, useState, useRef } from 'react'
-import { useGameBatchEditorStore } from '../GameBatchEditor/store'
+import { GameList } from './GameList'
 
 interface LibrarybarStore {
   query: string
@@ -166,6 +166,7 @@ export function Librarybar(): JSX.Element {
             <SelectContent>
               <SelectGroup>
                 <SelectLabel>分组依据</SelectLabel>
+                <SelectItem value="none">无分组</SelectItem>
                 <SelectItem value="collection">收藏</SelectItem>
                 <SelectItem value="developers">开发商</SelectItem>
                 <SelectItem value="genres">类别</SelectItem>

--- a/src/renderer/src/components/ui/nav.tsx
+++ b/src/renderer/src/components/ui/nav.tsx
@@ -30,9 +30,7 @@ export function Nav({
               : 'hover:bg-accent hover:text-accent-foreground rounded-none'
             break
           case 'sidebar':
-            variantStyles = isActive
-              ? 'bg-accent text-accent-foreground shadow-md'
-              : 'hover:bg-accent hover:text-accent-foreground'
+            variantStyles = isActive ? 'bg-accent shadow-md' : 'hover:bg-accent'
             break
           case 'librarybar':
             variantStyles = isActive

--- a/src/renderer/src/components/ui/nav.tsx
+++ b/src/renderer/src/components/ui/nav.tsx
@@ -26,11 +26,13 @@ export function Nav({
         switch (variant) {
           case 'gameList':
             variantStyles = isActive
-              ? 'bg-accent text-accent-foreground rounded-none shadow-md'
-              : 'hover:bg-accent hover:text-accent-foreground rounded-none'
+              ? 'bg-accent rounded-none shadow-md'
+              : 'hover:bg-accent rounded-none'
             break
           case 'sidebar':
-            variantStyles = isActive ? 'bg-accent shadow-md' : 'hover:bg-accent'
+            variantStyles = isActive
+              ? 'bg-accent text-accent-foreground shadow-md'
+              : 'hover:bg-accent hover:text-accent-foreground '
             break
           case 'librarybar':
             variantStyles = isActive


### PR DESCRIPTION
本地游戏标识：
- 增加了在列表右侧使用图标标识本地游戏的功能
- 开启高亮本地游戏时，选中某一游戏只改变背景颜色，不改变文本颜色，避免本地游戏高亮与选中高亮混淆

游戏列表中的选中游戏高亮：
从主页点击游戏时，边栏中对应游戏项可能无法正确高亮。比如所有游戏一栏中的对应游戏能够高亮，但是上面的按游戏状态分类中的对应项没有高亮。同时快速定位按钮会定位到排列靠前的对应游戏，所以总是定位到按游戏状态分类里面那个没有被高亮的项目。

其他：
- 增加了不按任何分组显示游戏的选项