### PR TITLE
Adapt the drop indicator to the grid layout

### DIFF
--- a/src/renderer/src/components/Showcase/Collections.tsx
+++ b/src/renderer/src/components/Showcase/Collections.tsx
@@ -1,10 +1,10 @@
-import { cn } from '~/utils'
-import { Separator } from '@ui/separator'
 import { Button } from '@ui/button'
-import { useCollections } from '~/hooks'
-import { CollectionPoster } from './posters/CollectionPoster'
-import { useRef } from 'react'
+import { Separator } from '@ui/separator'
 import { throttle } from 'lodash'
+import { useRef } from 'react'
+import { useCollections } from '~/hooks'
+import { cn } from '~/utils'
+import { CollectionPoster } from './posters/CollectionPoster'
 
 export function Collections(): JSX.Element {
   const { collections } = useCollections()
@@ -60,14 +60,21 @@ export function Collections(): JSX.Element {
         )}
       >
         {/* The wrapper ensures that each Poster maintains a fixed width */}
-        {Object.keys(collections).map((collectionId) => (
+        {Object.keys(collections).map((collectionId, index) => (
           <div
             key={collectionId}
             className={cn(
               'flex-shrink-0' // Preventing compression
             )}
           >
-            <CollectionPoster collectionId={collectionId} />
+            <CollectionPoster
+              collectionId={collectionId}
+              position={
+                (index === 0 && 'left') ||
+                (index === Object.keys(collections).length - 1 && 'right') ||
+                'center'
+              }
+            />
           </div>
         ))}
       </div>

--- a/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
@@ -54,10 +54,14 @@ function Preview({
 
 export function CollectionPoster({
   collectionId,
-  className
+  className,
+  parentGap = 24,
+  position = 'center'
 }: {
   collectionId: string
   className?: string
+  parentGap?: number
+  position?: 'right' | 'left' | 'center'
 }): JSX.Element {
   const navigate = useNavigate()
   const { collections, reorderCollections } = useCollections()
@@ -196,7 +200,12 @@ export function CollectionPoster({
           </div>
         )}
 
-        {closestEdge && <DropIndicator edge={closestEdge} gap="24px" />}
+        {closestEdge && (
+          <DropIndicator
+            edge={closestEdge}
+            gap={closestEdge === position ? '10px' : `${parentGap}px`}
+          />
+        )}
         {previewState.type === 'preview'
           ? createPortal(
               <Preview collectionLength={length} collectionName={collectionName} />,

--- a/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
@@ -203,7 +203,7 @@ export function CollectionPoster({
         {closestEdge && (
           <DropIndicator
             edge={closestEdge}
-            gap={closestEdge === position ? '10px' : `${parentGap}px`}
+            gap={closestEdge === position ? '16px' : `${parentGap}px`}
           />
         )}
         {previewState.type === 'preview'

--- a/src/renderer/src/components/Showcase/posters/GamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/GamePoster.tsx
@@ -55,12 +55,16 @@ export function GamePoster({
   gameId,
   groupId,
   className,
-  dragScenario
+  dragScenario,
+  parentGap = 0,
+  position = 'center'
 }: {
   gameId: string
   groupId?: string
   className?: string
   dragScenario?: string
+  parentGap?: number
+  position?: 'right' | 'left' | 'center'
 }): JSX.Element {
   const navigate = useNavigate()
   const { gameIndex } = useGameIndexManager()
@@ -121,7 +125,7 @@ export function GamePoster({
             nativeSetDragImage
           })
         },
-        getInitialData: () => ({ dragScenario: 'reorder-collections', uuid: gameId }),
+        getInitialData: () => ({ dragScenario: dragScenario, uuid: gameId }),
         onDragStart: () => {
           setIsDraggingGlobal(true)
           setDragging(true)
@@ -142,7 +146,7 @@ export function GamePoster({
 
       dropTargetForElements({
         element: el,
-        canDrop: ({ source }) => source.data.dragScenario === 'reorder-collections',
+        canDrop: ({ source }) => source.data.dragScenario === dragScenario,
         getData: ({ input, element }) => {
           // your base data you want to attach to the drop target
           const data = { uuid: gameId }
@@ -312,7 +316,12 @@ export function GamePoster({
           </HoverCardContent>
         </HoverCard>
       )}
-      {closestEdge && <DropIndicator edge={closestEdge} gap="24px" />}
+      {closestEdge && (
+        <DropIndicator
+          edge={closestEdge}
+          gap={closestEdge === position ? '10px' : `${parentGap}px`}
+        />
+      )}
       {previewState.type === 'preview'
         ? createPortal(<Preview title={gameData.name ?? ''} />, previewState.container)
         : null}

--- a/src/renderer/src/components/Showcase/posters/GamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/GamePoster.tsx
@@ -319,7 +319,7 @@ export function GamePoster({
       {closestEdge && (
         <DropIndicator
           edge={closestEdge}
-          gap={closestEdge === position ? '10px' : `${parentGap}px`}
+          gap={closestEdge === position ? '16px' : `${parentGap}px`}
         />
       )}
       {previewState.type === 'preview'


### PR DESCRIPTION
- 动态计算拖拽提示器的位置，保证在间距变化时仍在正中间显示
- 对于左右两侧的元素，为避免提示器渲染到可视区域外，使用更小的渲染偏移