### PR TITLE
Optimized the experience of the context/drop-down menu of game Config

### DIFF
--- a/src/renderer/src/components/Game/Config/ManageMenu/NameEditorDialog.tsx
+++ b/src/renderer/src/components/Game/Config/ManageMenu/NameEditorDialog.tsx
@@ -1,24 +1,19 @@
-import { Dialog, DialogContent, DialogTrigger } from '@ui/dialog'
-import { Input } from '@ui/input'
 import { Button } from '@ui/button'
-import { cn } from '~/utils'
+import { Dialog, DialogContent } from '@ui/dialog'
+import { Input } from '@ui/input'
 import { useDBSyncedState } from '~/hooks'
+import { cn } from '~/utils'
 
 export function NameEditorDialog({
   gameId,
-  isOpen,
-  setIsOpen,
-  children
+  setIsOpen
 }: {
   gameId: string
-  isOpen: boolean
   setIsOpen: (value: boolean) => void
-  children: React.ReactNode
 }): JSX.Element {
   const [gameName, setGameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
   return (
-    <Dialog open={isOpen}>
-      <DialogTrigger className={cn('w-full')}>{children}</DialogTrigger>
+    <Dialog open={true} onOpenChange={setIsOpen}>
       <DialogContent showCloseButton={false} className={cn('w-[500px] flex flex-row gap-3')}>
         <Input
           className={cn('w-full')}
@@ -30,13 +25,7 @@ export function NameEditorDialog({
             if (e.key === 'Enter') setIsOpen(false)
           }}
         />
-        <Button
-          onClick={() => {
-            setIsOpen(false)
-          }}
-        >
-          确定
-        </Button>
+        <Button onClick={() => setIsOpen(false)}>确定</Button>
       </DialogContent>
     </Dialog>
   )

--- a/src/renderer/src/components/Game/Config/ManageMenu/PlayingTimeEditorDialog.tsx
+++ b/src/renderer/src/components/Game/Config/ManageMenu/PlayingTimeEditorDialog.tsx
@@ -1,22 +1,18 @@
-import { Dialog, DialogContent, DialogTrigger } from '@ui/dialog'
-import { Input } from '@ui/input'
 import { Button } from '@ui/button'
-import { cn, formatTimeToChinese } from '~/utils'
-import { useDBSyncedState } from '~/hooks'
+import { Dialog, DialogContent } from '@ui/dialog'
+import { Input } from '@ui/input'
+import { Parser } from 'expr-eval'
 import { toNumber } from 'lodash'
 import { useState } from 'react'
-import { Parser } from 'expr-eval'
+import { useDBSyncedState } from '~/hooks'
+import { cn, formatTimeToChinese } from '~/utils'
 
 export function PlayingTimeEditorDialog({
   gameId,
-  isOpen,
-  setIsOpen,
-  children
+  setIsOpen
 }: {
   gameId: string
-  isOpen: boolean
   setIsOpen: (value: boolean) => void
-  children: React.ReactNode
 }): JSX.Element {
   const [playingTime, setPlayingTime] = useDBSyncedState(0, `games/${gameId}/record.json`, [
     'playingTime'
@@ -68,8 +64,7 @@ export function PlayingTimeEditorDialog({
   }
 
   return (
-    <Dialog open={isOpen}>
-      <DialogTrigger className={cn('w-full')}>{children}</DialogTrigger>
+    <Dialog open={true} onOpenChange={setIsOpen}>
       <DialogContent showCloseButton={false} className={cn('w-[500px] flex flex-col gap-3 py-5')}>
         <div className={cn('text-xs')}>支持四则运算表达式</div>
         <div className={cn('flex flex-row gap-3 items-center')}>

--- a/src/renderer/src/components/Game/Config/ManageMenu/main.tsx
+++ b/src/renderer/src/components/Game/Config/ManageMenu/main.tsx
@@ -1,30 +1,33 @@
 import {
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuPortal,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger
 } from '@ui/dropdown-menu'
-import { useDBSyncedState } from '~/hooks'
-import { ipcInvoke } from '~/utils'
-import { NameEditorDialog } from './NameEditorDialog'
-import { PlayingTimeEditorDialog } from './PlayingTimeEditorDialog'
-import { DeleteGameAlert } from './DeleteGameAlert'
-import { useState } from 'react'
 import { toast } from 'sonner'
+import { useDBSyncedState } from '~/hooks'
 import { useGameAdderStore } from '~/pages/GameAdder/store'
+import { ipcInvoke } from '~/utils'
+import { DeleteGameAlert } from './DeleteGameAlert'
 
-export function ManageMenu({ gameId }: { gameId: string }): JSX.Element {
+export function ManageMenu({
+  gameId,
+  openNameEditorDialog,
+  openPlayingTimeEditorDialog
+}: {
+  gameId: string
+  openNameEditorDialog: () => void
+  openPlayingTimeEditorDialog: () => void
+}): JSX.Element {
   const [gamePath] = useDBSyncedState('', `games/${gameId}/path.json`, ['gamePath'])
   const [gameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
   const [logoVisible, setLogoVisible] = useDBSyncedState(true, `games/${gameId}/utils.json`, [
     'logo',
     'visible'
   ])
-  const [isNameEditorDialogOpen, setIsNameEditorDialogOpen] = useState(false)
-  const [isPlayingTimeEditorDialogOpen, setIsPlayingTimeEditorDialogOpen] = useState(false)
   const { setIsOpen, setDbId, setName } = useGameAdderStore()
   return (
     <DropdownMenuGroup>
@@ -32,20 +35,7 @@ export function ManageMenu({ gameId }: { gameId: string }): JSX.Element {
         <DropdownMenuSubTrigger>管理</DropdownMenuSubTrigger>
         <DropdownMenuPortal>
           <DropdownMenuSubContent>
-            <NameEditorDialog
-              gameId={gameId}
-              isOpen={isNameEditorDialogOpen}
-              setIsOpen={setIsNameEditorDialogOpen}
-            >
-              <DropdownMenuItem
-                onSelect={(e) => {
-                  e.preventDefault()
-                  setIsNameEditorDialogOpen(true)
-                }}
-              >
-                重命名
-              </DropdownMenuItem>
-            </NameEditorDialog>
+            <DropdownMenuItem onSelect={openNameEditorDialog}>重命名</DropdownMenuItem>
             {!logoVisible && (
               <DropdownMenuItem
                 onClick={() => {
@@ -55,20 +45,7 @@ export function ManageMenu({ gameId }: { gameId: string }): JSX.Element {
                 显示徽标
               </DropdownMenuItem>
             )}
-            <PlayingTimeEditorDialog
-              gameId={gameId}
-              isOpen={isPlayingTimeEditorDialogOpen}
-              setIsOpen={setIsPlayingTimeEditorDialogOpen}
-            >
-              <DropdownMenuItem
-                onClick={(e) => {
-                  e.preventDefault()
-                  setIsPlayingTimeEditorDialogOpen(true)
-                }}
-              >
-                修改游玩时间
-              </DropdownMenuItem>
-            </PlayingTimeEditorDialog>
+            <DropdownMenuItem onClick={openPlayingTimeEditorDialog}>修改游玩时间</DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => {
                 setDbId(gameId)

--- a/src/renderer/src/components/Game/Config/main.tsx
+++ b/src/renderer/src/components/Game/Config/main.tsx
@@ -6,16 +6,20 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '@ui/dropdown-menu'
-import { cn } from '~/utils'
-import { CollectionMenu } from './CollectionMenu'
-import { AttributesDialog } from './AttributesDialog'
-import { ManageMenu } from './ManageMenu'
 import React from 'react'
 import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
+import { cn } from '~/utils'
+import { AttributesDialog } from './AttributesDialog'
+import { CollectionMenu } from './CollectionMenu'
+import { ManageMenu } from './ManageMenu'
+import { NameEditorDialog } from './ManageMenu/NameEditorDialog'
+import { PlayingTimeEditorDialog } from './ManageMenu/PlayingTimeEditorDialog'
 
 export function Config({ gameId }: { gameId: string }): JSX.Element {
   const [isAttributesDialogOpen, setIsAttributesDialogOpen] = React.useState(false)
   const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
+  const [isPlayingTimeEditorDialogOpen, setIsPlayingTimeEditorDialogOpen] = React.useState(false)
+  const [isNameEditorDialogOpen, setIsNameEditorDialogOpen] = React.useState(false)
   return (
     <>
       <DropdownMenu>
@@ -30,7 +34,11 @@ export function Config({ gameId }: { gameId: string }): JSX.Element {
             openAddCollectionDialog={() => setIsAddCollectionDialogOpen(true)}
           />
           <DropdownMenuSeparator />
-          <ManageMenu gameId={gameId} />
+          <ManageMenu
+            gameId={gameId}
+            openNameEditorDialog={() => setIsNameEditorDialogOpen(true)}
+            openPlayingTimeEditorDialog={() => setIsPlayingTimeEditorDialogOpen(true)}
+          />
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => setIsAttributesDialogOpen(true)}>
             <div>属性</div>
@@ -42,6 +50,12 @@ export function Config({ gameId }: { gameId: string }): JSX.Element {
       )}
       {isAddCollectionDialogOpen && (
         <AddCollectionDialog gameIds={[gameId]} setIsOpen={setIsAddCollectionDialogOpen} />
+      )}
+      {isNameEditorDialogOpen && (
+        <NameEditorDialog gameId={gameId} setIsOpen={setIsNameEditorDialogOpen} />
+      )}
+      {isPlayingTimeEditorDialogOpen && (
+        <PlayingTimeEditorDialog gameId={gameId} setIsOpen={setIsPlayingTimeEditorDialogOpen} />
       )}
     </>
   )

--- a/src/renderer/src/components/Librarybar/GameNav.tsx
+++ b/src/renderer/src/components/Librarybar/GameNav.tsx
@@ -3,11 +3,13 @@ import { GameImage } from '@ui/game-image'
 import { Nav } from '@ui/nav'
 import React from 'react'
 import { useLocation } from 'react-router-dom'
+import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
+import { AttributesDialog } from '~/components/Game/Config/AttributesDialog'
+import { NameEditorDialog } from '~/components/Game/Config/ManageMenu/NameEditorDialog'
+import { PlayingTimeEditorDialog } from '~/components/Game/Config/ManageMenu/PlayingTimeEditorDialog'
 import { useDBSyncedState } from '~/hooks'
 import { cn } from '~/utils'
 import { GameNavCM } from '../contextMenu/GameNavCM'
-import { AddCollectionDialog } from '../dialog/AddCollectionDialog'
-import { AttributesDialog } from '../Game/Config/AttributesDialog'
 import { BatchGameNavCM } from '../GameBatchEditor/BatchGameNavCM'
 import { useGameBatchEditorStore } from '../GameBatchEditor/store'
 
@@ -27,6 +29,8 @@ export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }
   ])
   const [isAttributesDialogOpen, setIsAttributesDialogOpen] = React.useState(false)
   const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
+  const [isPlayingTimeEditorDialogOpen, setIsPlayingTimeEditorDialogOpen] = React.useState(false)
+  const [isNameEditorDialogOpen, setIsNameEditorDialogOpen] = React.useState(false)
   const { addGameId, removeGameId, clearGameIds, gameIds, lastSelectedId, setLastSelectedId } =
     useGameBatchEditorStore()
 
@@ -142,6 +146,8 @@ export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }
             gameId={gameId}
             openAttributesDialog={() => setIsAttributesDialogOpen(true)}
             openAddCollectionDialog={() => setIsAddCollectionDialogOpen(true)}
+            openNameEditorDialog={() => setIsNameEditorDialogOpen(true)}
+            openPlayingTimeEditorDialog={() => setIsPlayingTimeEditorDialogOpen(true)}
           />
         )}
       </ContextMenu>
@@ -150,6 +156,12 @@ export function GameNav({ gameId, groupId }: { gameId: string; groupId: string }
       )}
       {isAddCollectionDialogOpen && (
         <AddCollectionDialog gameIds={[gameId]} setIsOpen={setIsAddCollectionDialogOpen} />
+      )}
+      {isNameEditorDialogOpen && (
+        <NameEditorDialog gameId={gameId} setIsOpen={setIsNameEditorDialogOpen} />
+      )}
+      {isPlayingTimeEditorDialogOpen && (
+        <PlayingTimeEditorDialog gameId={gameId} setIsOpen={setIsPlayingTimeEditorDialogOpen} />
       )}
     </>
   )

--- a/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
@@ -1,15 +1,16 @@
-import { HoverCard, HoverCardContent, HoverCardTrigger } from '@ui/hover-card'
 import { ContextMenu, ContextMenuTrigger } from '@ui/context-menu'
-import { GameImage } from '~/components/ui/game-image'
-import { HoverBigCardAnimation } from '~/components/animations/HoverBigCard'
-import { cn } from '~/utils'
-import { GameNavCM } from '~/components/contextMenu/GameNavCM'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@ui/hover-card'
+import React, { MutableRefObject, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useGameIndexManager, useDBSyncedState } from '~/hooks'
-import { formatTimeToChinese, formatDateToChinese } from '~/utils'
-import { AttributesDialog } from '~/components/Game/Config/AttributesDialog'
-import React, { useRef, MutableRefObject } from 'react'
+import { HoverBigCardAnimation } from '~/components/animations/HoverBigCard'
+import { GameNavCM } from '~/components/contextMenu/GameNavCM'
 import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
+import { AttributesDialog } from '~/components/Game/Config/AttributesDialog'
+import { NameEditorDialog } from '~/components/Game/Config/ManageMenu/NameEditorDialog'
+import { PlayingTimeEditorDialog } from '~/components/Game/Config/ManageMenu/PlayingTimeEditorDialog'
+import { GameImage } from '~/components/ui/game-image'
+import { useDBSyncedState, useGameIndexManager } from '~/hooks'
+import { cn, formatDateToChinese, formatTimeToChinese } from '~/utils'
 
 export function BigGamePoster({
   gameId,
@@ -28,6 +29,8 @@ export function BigGamePoster({
   const [gameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
   const [isAttributesDialogOpen, setIsAttributesDialogOpen] = React.useState(false)
   const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
+  const [isPlayingTimeEditorDialogOpen, setIsPlayingTimeEditorDialogOpen] = React.useState(false)
+  const [isNameEditorDialogOpen, setIsNameEditorDialogOpen] = React.useState(false)
   const [isOpen, setIsOpen] = React.useState(false)
   const openTimeoutRef: MutableRefObject<NodeJS.Timeout | undefined> = useRef(undefined)
   const closeTimeoutRef: MutableRefObject<NodeJS.Timeout | undefined> = useRef(undefined)
@@ -121,6 +124,8 @@ export function BigGamePoster({
           gameId={gameId}
           openAttributesDialog={() => setIsAttributesDialogOpen(true)}
           openAddCollectionDialog={() => setIsAddCollectionDialogOpen(true)}
+          openNameEditorDialog={() => setIsNameEditorDialogOpen(true)}
+          openPlayingTimeEditorDialog={() => setIsPlayingTimeEditorDialogOpen(true)}
         />
       </ContextMenu>
 
@@ -129,6 +134,12 @@ export function BigGamePoster({
       )}
       {isAddCollectionDialogOpen && (
         <AddCollectionDialog gameIds={[gameId]} setIsOpen={setIsAddCollectionDialogOpen} />
+      )}
+      {isNameEditorDialogOpen && (
+        <NameEditorDialog gameId={gameId} setIsOpen={setIsNameEditorDialogOpen} />
+      )}
+      {isPlayingTimeEditorDialogOpen && (
+        <PlayingTimeEditorDialog gameId={gameId} setIsOpen={setIsPlayingTimeEditorDialogOpen} />
       )}
 
       <HoverCardContent

--- a/src/renderer/src/components/Showcase/posters/GamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/GamePoster.tsx
@@ -7,6 +7,8 @@ import { HoverCardAnimation } from '~/components/animations/HoverCard'
 import { GameNavCM } from '~/components/contextMenu/GameNavCM'
 import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
 import { AttributesDialog } from '~/components/Game/Config/AttributesDialog'
+import { NameEditorDialog } from '~/components/Game/Config/ManageMenu/NameEditorDialog'
+import { PlayingTimeEditorDialog } from '~/components/Game/Config/ManageMenu/PlayingTimeEditorDialog'
 import { useDragContext } from '~/components/Showcase/CollectionGames'
 import { useCollections, useDBSyncedState, useGameIndexManager } from '~/hooks'
 import { cn, formatDateToChinese, formatTimeToChinese } from '~/utils'
@@ -75,6 +77,8 @@ export function GamePoster({
   const [gameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
   const [isAttributesDialogOpen, setIsAttributesDialogOpen] = useState(false)
   const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = useState(false)
+  const [isPlayingTimeEditorDialogOpen, setIsPlayingTimeEditorDialogOpen] = useState(false)
+  const [isNameEditorDialogOpen, setIsNameEditorDialogOpen] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
   const openTimeoutRef: MutableRefObject<NodeJS.Timeout | undefined> = useRef(undefined)
   const closeTimeoutRef: MutableRefObject<NodeJS.Timeout | undefined> = useRef(undefined)
@@ -233,6 +237,8 @@ export function GamePoster({
               gameId={gameId}
               openAttributesDialog={() => setIsAttributesDialogOpen(true)}
               openAddCollectionDialog={() => setIsAddCollectionDialogOpen(true)}
+              openNameEditorDialog={() => setIsNameEditorDialogOpen(true)}
+              openPlayingTimeEditorDialog={() => setIsPlayingTimeEditorDialogOpen(true)}
             />
           </ContextMenu>
 
@@ -241,6 +247,12 @@ export function GamePoster({
           )}
           {isAddCollectionDialogOpen && (
             <AddCollectionDialog gameIds={[gameId]} setIsOpen={setIsAddCollectionDialogOpen} />
+          )}
+          {isNameEditorDialogOpen && (
+            <NameEditorDialog gameId={gameId} setIsOpen={setIsNameEditorDialogOpen} />
+          )}
+          {isPlayingTimeEditorDialogOpen && (
+            <PlayingTimeEditorDialog gameId={gameId} setIsOpen={setIsPlayingTimeEditorDialogOpen} />
           )}
 
           <HoverCardContent

--- a/src/renderer/src/components/contextMenu/GameNavCM/ManageMenu.tsx
+++ b/src/renderer/src/components/contextMenu/GameNavCM/ManageMenu.tsx
@@ -1,59 +1,36 @@
 import {
+  ContextMenuGroup,
   ContextMenuItem,
   ContextMenuSeparator,
   ContextMenuSub,
   ContextMenuSubContent,
-  ContextMenuSubTrigger,
-  ContextMenuGroup
+  ContextMenuSubTrigger
 } from '@ui/context-menu'
-import { useDBSyncedState } from '~/hooks'
-import { ipcInvoke } from '~/utils'
-import { NameEditorDialog } from '~/components/Game/Config/ManageMenu/NameEditorDialog'
-import { PlayingTimeEditorDialog } from '~/components/Game/Config/ManageMenu/PlayingTimeEditorDialog'
-import { DeleteGameAlert } from '~/components/Game/Config/ManageMenu/DeleteGameAlert'
-import { useState } from 'react'
 import { toast } from 'sonner'
+import { DeleteGameAlert } from '~/components/Game/Config/ManageMenu/DeleteGameAlert'
+import { useDBSyncedState } from '~/hooks'
 import { useGameAdderStore } from '~/pages/GameAdder/store'
+import { ipcInvoke } from '~/utils'
 
-export function ManageMenu({ gameId }: { gameId: string }): JSX.Element {
+export function ManageMenu({
+  gameId,
+  openNameEditorDialog,
+  openPlayingTimeEditorDialog
+}: {
+  gameId: string
+  openNameEditorDialog: () => void
+  openPlayingTimeEditorDialog: () => void
+}): JSX.Element {
   const [gamePath] = useDBSyncedState('', `games/${gameId}/path.json`, ['gamePath'])
   const [gameName] = useDBSyncedState('', `games/${gameId}/metadata.json`, ['name'])
   const { setIsOpen, setDbId, setName } = useGameAdderStore()
-  const [isNameEditorDialogOpen, setIsNameEditorDialogOpen] = useState(false)
-  const [isPlayingTimeEditorDialogOpen, setIsPlayingTimeEditorDialogOpen] = useState(false)
   return (
     <ContextMenuGroup>
       <ContextMenuSub>
         <ContextMenuSubTrigger>管理</ContextMenuSubTrigger>
         <ContextMenuSubContent>
-          <NameEditorDialog
-            gameId={gameId}
-            isOpen={isNameEditorDialogOpen}
-            setIsOpen={setIsNameEditorDialogOpen}
-          >
-            <ContextMenuItem
-              onSelect={(e) => {
-                e.preventDefault()
-                setIsNameEditorDialogOpen(true)
-              }}
-            >
-              重命名
-            </ContextMenuItem>
-          </NameEditorDialog>
-          <PlayingTimeEditorDialog
-            gameId={gameId}
-            isOpen={isPlayingTimeEditorDialogOpen}
-            setIsOpen={setIsPlayingTimeEditorDialogOpen}
-          >
-            <ContextMenuItem
-              onClick={(e) => {
-                e.preventDefault()
-                setIsPlayingTimeEditorDialogOpen(true)
-              }}
-            >
-              修改游玩时间
-            </ContextMenuItem>
-          </PlayingTimeEditorDialog>
+          <ContextMenuItem onSelect={openNameEditorDialog}>重命名</ContextMenuItem>
+          <ContextMenuItem onClick={openPlayingTimeEditorDialog}>修改游玩时间</ContextMenuItem>
           <ContextMenuItem
             onClick={() => {
               setDbId(gameId)

--- a/src/renderer/src/components/contextMenu/GameNavCM/main.tsx
+++ b/src/renderer/src/components/contextMenu/GameNavCM/main.tsx
@@ -1,19 +1,23 @@
 import { ContextMenuContent, ContextMenuItem, ContextMenuSeparator } from '@ui/context-menu'
+import { useRunningGames } from '~/pages/Library/store'
 import { cn } from '~/utils'
-import { ManageMenu } from './ManageMenu'
-import { CollectionMenu } from './CollectionMenu'
 import { StartGame } from '../../Game/StartGame'
 import { StopGame } from '../../Game/StopGame'
-import { useRunningGames } from '~/pages/Library/store'
+import { CollectionMenu } from './CollectionMenu'
+import { ManageMenu } from './ManageMenu'
 
 export function GameNavCM({
   gameId,
   openAttributesDialog,
-  openAddCollectionDialog
+  openAddCollectionDialog,
+  openNameEditorDialog,
+  openPlayingTimeEditorDialog
 }: {
   gameId: string
   openAttributesDialog: () => void
   openAddCollectionDialog: () => void
+  openNameEditorDialog: () => void
+  openPlayingTimeEditorDialog: () => void
 }): JSX.Element {
   const { runningGames } = useRunningGames()
   return (
@@ -28,7 +32,11 @@ export function GameNavCM({
       <ContextMenuSeparator />
       <CollectionMenu gameId={gameId} openAddCollectionDialog={openAddCollectionDialog} />
       <ContextMenuSeparator />
-      <ManageMenu gameId={gameId} />
+      <ManageMenu
+        gameId={gameId}
+        openNameEditorDialog={openNameEditorDialog}
+        openPlayingTimeEditorDialog={openPlayingTimeEditorDialog}
+      />
       <ContextMenuSeparator />
       <ContextMenuItem onSelect={openAttributesDialog}>
         <div>属性</div>


### PR DESCRIPTION
优化了修改游戏时间 / 修改游戏名的对话框：
- 点击对话框以外的部分可以关闭对话框
  > 添加属性 onOpenChange={setIsOpen}
- 点击下拉菜单 / 右键菜单中的选项打开对话框后，不会残留下拉菜单 / 右键菜单