### PR TITLE
fix: Fixed date rendering error in monthly report calendar

### DIFF
--- a/src/renderer/src/components/ui/button.tsx
+++ b/src/renderer/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
 
 import { cn } from '~/utils'
 
@@ -15,7 +15,8 @@ const buttonVariants = cva(
           'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
         secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline'
+        link: 'text-primary underline-offset-4 hover:underline',
+        none: 'select-none'
       },
       size: {
         default: 'h-9 px-4 py-2',

--- a/src/renderer/src/pages/Record/MonthlyReport.tsx
+++ b/src/renderer/src/pages/Record/MonthlyReport.tsx
@@ -1,17 +1,17 @@
-import { useState } from 'react'
-import { useTranslation } from 'react-i18next'
-
-import { Card, CardContent, CardHeader, CardTitle } from '@ui/card'
-import { Button } from '@ui/button'
+import { Button, buttonVariants } from '@ui/button'
 import { Calendar } from '@ui/calendar'
-import { ChevronLeft, ChevronRight, Clock, CalendarIcon, Trophy } from 'lucide-react'
-import { CartesianGrid, XAxis, YAxis, Area, AreaChart } from 'recharts'
+import { Card, CardContent, CardHeader, CardTitle } from '@ui/card'
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@ui/chart'
 import { Separator } from '@ui/separator'
+import { CalendarIcon, ChevronLeft, ChevronRight, Clock, Trophy } from 'lucide-react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
+import { cn } from '~/utils'
 
-import { StatCard } from './StatCard'
-import { GameRankingItem } from './GameRankingItem'
 import { getMonthlyPlayData } from '~/stores/game/recordUtils'
+import { GameRankingItem } from './GameRankingItem'
+import { StatCard } from './StatCard'
 
 export function MonthlyReport(): JSX.Element {
   const { t } = useTranslation('record')
@@ -224,18 +224,32 @@ export function MonthlyReport(): JSX.Element {
           </CardHeader>
           <CardContent>
             <Calendar
-              mode="single"
+              mode="default"
               selected={selectedDate}
               month={selectedDate} // Controls the displayed month
               onMonthChange={(date) => setSelectedDate(date)}
-              className="w-full border rounded-md"
+              className="w-full border rounded-md select-none"
+              classNames={{
+                day: cn(
+                  buttonVariants({ variant: 'none' }),
+                  'h-8 w-8 p-0 font-normal aria-selected:opacity-100'
+                )
+              }}
               modifiers={{
                 played: (date) => {
-                  const dateStr = date.toISOString().split('T')[0]
+                  const dateStr = date.toLocaleDateString('en-CA')
                   return !!monthData.dailyPlayTime[dateStr] && monthData.dailyPlayTime[dateStr] > 0
                 }
               }}
               modifiersStyles={{
+                today: {
+                  backgroundColor: 'hsl(var(--card))',
+                  color: 'inherit'
+                },
+                selected: {
+                  backgroundColor: 'hsl(var(--card))',
+                  color: 'inherit'
+                },
                 played: {
                   backgroundColor: 'hsl(var(--primary))',
                   color: 'hsl(var(--primary-foreground))'

--- a/src/renderer/src/pages/Record/MonthlyReport.tsx
+++ b/src/renderer/src/pages/Record/MonthlyReport.tsx
@@ -7,9 +7,9 @@ import { CalendarIcon, ChevronLeft, ChevronRight, Clock, Trophy } from 'lucide-r
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
-import { cn } from '~/utils'
 
 import { getMonthlyPlayData } from '~/stores/game/recordUtils'
+import { cn } from '~/utils'
 import { GameRankingItem } from './GameRankingItem'
 import { StatCard } from './StatCard'
 
@@ -233,7 +233,8 @@ export function MonthlyReport(): JSX.Element {
                 day: cn(
                   buttonVariants({ variant: 'none' }),
                   'h-8 w-8 p-0 font-normal aria-selected:opacity-100'
-                )
+                ),
+                day_outside: 'invisible'
               }}
               modifiers={{
                 played: (date) => {


### PR DESCRIPTION
修复若干月度报告日历中日期的不正确标记：
- 当前日期会被高亮标记
- 切换到其他月份时，1号会被高亮标记
- 存在游玩记录的日期高亮标记整体后移了一天

另外，把月份范围外的日期隐藏了
> 原先的变淡总感觉对比不够强