### PR TITLE
Opti

### DIFF
--- a/src/renderer/src/components/Game/Overview/Information/InformationCard.tsx
+++ b/src/renderer/src/components/Game/Overview/Information/InformationCard.tsx
@@ -1,6 +1,6 @@
-import { useTranslation } from 'react-i18next'
 import { Separator } from '@ui/separator'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { useGameState } from '~/hooks'
 import { cn, copyWithToast } from '~/utils'
 import { FilterAdder } from '../../FilterAdder'
@@ -43,7 +43,7 @@ export function InformationCard({
         genres,
         platforms
       })
-        .map(([key, value]) => `${fields[key]}: ${value}`)
+        .map(([key, value]) => `${fields[key]}: ${Array.isArray(value) ? value.join(', ') : value}`)
         .join('\n')
     )
   }
@@ -83,7 +83,7 @@ export function InformationCard({
         {/* developers */}
         <div
           className={cn('whitespace-nowrap select-none cursor-pointer')}
-          onClick={() => copyWithToast(developers.join(','))}
+          onClick={() => copyWithToast(developers.join(', '))}
         >
           {t('detail.overview.information.fields.developers')}
         </div>
@@ -105,7 +105,7 @@ export function InformationCard({
         {/* publishers */}
         <div
           className={cn('whitespace-nowrap select-none cursor-pointer')}
-          onClick={() => copyWithToast(publishers.join(','))}
+          onClick={() => copyWithToast(publishers.join(', '))}
         >
           {t('detail.overview.information.fields.publishers')}
         </div>
@@ -146,7 +146,7 @@ export function InformationCard({
         {/* platforms */}
         <div
           className={cn('whitespace-nowrap select-none cursor-pointer')}
-          onClick={() => copyWithToast(platforms.join(','))}
+          onClick={() => copyWithToast(platforms.join(', '))}
         >
           {t('detail.overview.information.fields.platforms')}
         </div>
@@ -165,7 +165,7 @@ export function InformationCard({
         {/* genres */}
         <div
           className={cn('whitespace-nowrap select-none cursor-pointer')}
-          onClick={() => copyWithToast(genres.join(','))}
+          onClick={() => copyWithToast(genres.join(', '))}
         >
           {t('detail.overview.information.fields.genres')}
         </div>

--- a/src/renderer/src/components/Game/Overview/Tags/TagsCard.tsx
+++ b/src/renderer/src/components/Game/Overview/Tags/TagsCard.tsx
@@ -1,11 +1,11 @@
-import { useTranslation } from 'react-i18next'
 import { Separator } from '@ui/separator'
 import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useGameState } from '~/hooks'
 import { cn, copyWithToast } from '~/utils'
 import { FilterAdder } from '../../FilterAdder'
-import { TagsDialog } from './TagsDialog'
 import { SearchTagsDialog } from './SearchTagsDialog'
+import { TagsDialog } from './TagsDialog'
 
 export function TagsCard({
   gameId,
@@ -26,7 +26,10 @@ export function TagsCard({
   return (
     <div className={cn(className, 'group')}>
       <div className={cn('flex flex-row justify-between items-center')}>
-        <div className={cn('select-none cursor-pointer')} onClick={() => copyWithToast(`${tags}`)}>
+        <div
+          className={cn('select-none cursor-pointer')}
+          onClick={() => copyWithToast(`${tags.join(', ')}`)}
+        >
           {t('detail.overview.sections.tags')}
         </div>
         <div className="flex items-center gap-3">

--- a/src/renderer/src/components/Game/Overview/extraInformation/ExtraInformationCard.tsx
+++ b/src/renderer/src/components/Game/Overview/extraInformation/ExtraInformationCard.tsx
@@ -1,10 +1,10 @@
-import { useTranslation } from 'react-i18next'
 import { Separator } from '@ui/separator'
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { useGameState } from '~/hooks'
 import { cn, copyWithToast } from '~/utils'
-import { ExtraInformationDialog } from './ExtraInformationDialog'
 import { FilterAdder } from '../../FilterAdder'
+import { ExtraInformationDialog } from './ExtraInformationDialog'
 
 export function ExtraInformationCard({
   gameId,
@@ -49,7 +49,7 @@ export function ExtraInformationCard({
             <React.Fragment key={index}>
               <div
                 className={cn('whitespace-nowrap select-none cursor-pointer')}
-                onClick={() => copyWithToast(item.key)}
+                onClick={() => copyWithToast(item.value.join(', '))}
               >
                 {item.key}
               </div>

--- a/src/renderer/src/components/Game/Save/main.tsx
+++ b/src/renderer/src/components/Game/Save/main.tsx
@@ -2,10 +2,10 @@ import { Button } from '@ui/button'
 import { Input } from '@ui/input'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@ui/table'
 import { isEqual } from 'lodash'
+import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { useGameLocalState, useGameState } from '~/hooks'
 import { cn, ipcInvoke } from '~/utils'
-import { useTranslation } from 'react-i18next'
 
 export function Save({ gameId }: { gameId: string }): JSX.Element {
   const { t } = useTranslation('game')
@@ -103,7 +103,7 @@ export function Save({ gameId }: { gameId: string }): JSX.Element {
                           <Button
                             variant={'outline'}
                             size={'icon'}
-                            className={cn(saveList[saveId]?.locked ? 'border-ring' : '')}
+                            className={cn('h-8 w-8', saveList[saveId]?.locked ? 'border-ring' : '')}
                             onClick={() => toggleLock(saveId)}
                           >
                             <span

--- a/src/renderer/src/components/Librarybar/main.tsx
+++ b/src/renderer/src/components/Librarybar/main.tsx
@@ -12,14 +12,14 @@ import {
 } from '@ui/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@ui/tooltip'
 import { isEqual } from 'lodash'
+import { useTranslation } from 'react-i18next'
 import { useConfigState } from '~/hooks'
 import { cn } from '~/utils'
 import { Filter } from './Filter'
 import { useFilterStore } from './Filter/store'
 import { GameList } from './GameList'
-import { useLibrarybarStore } from './store'
 import { PositionButton } from './PositionButton'
-import { useTranslation } from 'react-i18next'
+import { useLibrarybarStore } from './store'
 
 export function Librarybar(): JSX.Element {
   const { t } = useTranslation('game')
@@ -28,6 +28,7 @@ export function Librarybar(): JSX.Element {
   const setQuery = useLibrarybarStore((state) => state.setQuery)
   const filter = useFilterStore((state) => state.filter)
   const toggleFilterMenu = useFilterStore((state) => state.toggleFilterMenu)
+  const clearFilter = useFilterStore((state) => state.clearFilter)
 
   console.warn(`[DEBUG] Librarybar`)
 
@@ -75,6 +76,20 @@ export function Librarybar(): JSX.Element {
               <TooltipContent side="bottom">{t('librarybar.search.tooltip')}</TooltipContent>
             </Tooltip>
           </div>
+          {(!isEqual(filter, {}) || query) && (
+            <div>
+              <Button
+                onClick={() => {
+                  clearFilter()
+                  setQuery('')
+                }}
+                variant="default"
+                size={'icon'}
+              >
+                <span className={cn('icon-[mdi--filter-variant-remove] w-5 h-5')}></span>
+              </Button>
+            </div>
+          )}
           <div>
             <Filter>
               <Button onClick={toggleFilterMenu} variant="default" size={'icon'}>

--- a/src/renderer/src/utils/common.ts
+++ b/src/renderer/src/utils/common.ts
@@ -1,11 +1,13 @@
 import { Element, HTMLReactParserOptions } from 'html-react-parser'
+import i18next from 'i18next'
 import { toast } from 'sonner'
-import { ipcSend, ipcInvoke } from '~/utils'
 import { useRunningGames } from '~/pages/Library/store'
 import { getGameLocalStore, getGameStore } from '~/stores/game'
-import i18next from 'i18next'
+import { ipcInvoke, ipcSend } from '~/utils'
 
 export function copyWithToast(content: string): void {
+  if (!content) return
+
   navigator.clipboard
     .writeText(content)
     .then(() => {


### PR DESCRIPTION
- 调整了存档管理页面中”锁定“按钮的尺寸，使其大小与其他按钮一致
- 在侧栏增加了清除筛选器与查询的按钮，从而无需进入二级菜单中进行清除
- 优化了游戏概览页信息的快速复制格式（给列表项的分隔加了个空格）
- 附加信息里面的快速复制，点击小项复制的是键名，改成了复制对应的键值