### PR TITLE
feat: Optimized the sorting function of the librarybar

### DIFF
--- a/src/renderer/src/components/Librarybar/GameList/AllGame.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/AllGame.tsx
@@ -1,21 +1,10 @@
-import { cn } from '~/utils'
 import { AccordionContent, AccordionItem, AccordionTrigger } from '@ui/accordion'
-import { Button } from '@ui/button'
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue
-} from '@ui/select'
-import { ContextMenuContent, ContextMenuTrigger, ContextMenu } from '@ui/context-menu'
+import { useTranslation } from 'react-i18next'
+import { LazyLoadComponent, trackWindowScroll } from 'react-lazy-load-image-component'
 import { useConfigState } from '~/hooks'
 import { sortGames } from '~/stores/game'
+import { cn } from '~/utils'
 import { GameNav } from '../GameNav'
-import { LazyLoadComponent, trackWindowScroll } from 'react-lazy-load-image-component'
-import { useTranslation } from 'react-i18next'
 
 function PlaceHolder(): JSX.Element {
   return <div className={cn('p-3 h-5 rounded-none bg-transparent')}></div>
@@ -26,68 +15,19 @@ export function AllGameComponent({
 }: {
   scrollPosition: { x: number; y: number }
 }): JSX.Element {
-  const [by, setBy] = useConfigState('game.gameList.sort.by')
-  const [order, setOrder] = useConfigState('game.gameList.sort.order')
-  const toggleOrder = (): void => {
-    setOrder(order === 'asc' ? 'desc' : 'asc')
-  }
+  const [by, _setBy] = useConfigState('game.gameList.sort.by')
+  const [order, _setOrder] = useConfigState('game.gameList.sort.order')
   const games = sortGames(by, order)
   const { t } = useTranslation('game')
 
   return (
     <AccordionItem value="all">
-      <ContextMenu>
-        <ContextMenuTrigger className={cn('rounded-none')}>
-          <AccordionTrigger className={cn('bg-accent/30 text-xs p-1 pl-2')}>
-            <div className={cn('flex flex-row items-center justify-start gap-1')}>
-              <div className={cn('text-xs')}>{t('list.all.title')}</div>
-              <div className={cn('text-2xs text-foreground/50')}>({games.length})</div>
-            </div>
-          </AccordionTrigger>
-        </ContextMenuTrigger>
-        <ContextMenuContent className={cn('w-full p-3')}>
-          <div className={cn('flex flex-row gap-5 items-center justify-center')}>
-            <div className={cn('flex flex-row gap-1 items-center justify-center')}>
-              <div className={cn('text-sm whitespace-nowrap')}>{t('list.all.sortBy')}：</div>
-              <Select value={by} onValueChange={setBy} defaultValue="name">
-                <SelectTrigger className={cn('w-[120px] h-[26px] text-xs')}>
-                  <SelectValue placeholder="Select a fruit" className={cn('text-xs')} />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectLabel>{t('list.all.sortBy')}：</SelectLabel>
-                    <SelectItem value="metadata.name">{t('list.all.sortOptions.name')}</SelectItem>
-                    <SelectItem value="metadata.releaseDate">
-                      {t('list.all.sortOptions.releaseDate')}
-                    </SelectItem>
-                    <SelectItem value="record.lastRunDate">
-                      {t('list.all.sortOptions.lastRunDate')}
-                    </SelectItem>
-                    <SelectItem value="record.addDate">
-                      {t('list.all.sortOptions.addDate')}
-                    </SelectItem>
-                    <SelectItem value="record.playTime">
-                      {t('list.all.sortOptions.playTime')}
-                    </SelectItem>
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </div>
-            <Button
-              variant={'outline'}
-              size={'icon'}
-              className={cn('h-[26px] w-[26px] -ml-3')}
-              onClick={toggleOrder}
-            >
-              {order === 'asc' ? (
-                <span className={cn('icon-[mdi--arrow-up] w-4 h-4')}></span>
-              ) : (
-                <span className={cn('icon-[mdi--arrow-down] w-4 h-4')}></span>
-              )}
-            </Button>
-          </div>
-        </ContextMenuContent>
-      </ContextMenu>
+      <AccordionTrigger className={cn('bg-accent/30 text-xs p-1 pl-2')}>
+        <div className={cn('flex flex-row items-center justify-start gap-1')}>
+          <div className={cn('text-xs')}>{t('list.all.title')}</div>
+          <div className={cn('text-2xs text-foreground/50')}>({games.length})</div>
+        </div>
+      </AccordionTrigger>
       <AccordionContent className={cn('rounded-none pt-1 flex flex-col gap-1')}>
         {games.map((gameId) => (
           <LazyLoadComponent

--- a/src/renderer/src/components/Librarybar/GameList/FilterGame.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/FilterGame.tsx
@@ -1,14 +1,17 @@
-import { cn } from '~/utils'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@ui/accordion'
 import { ScrollArea } from '@ui/scroll-area'
-import { GameNav } from '../GameNav'
-import { useFilterStore } from '../Filter/store'
-import { filterGames } from '~/stores/game'
 import { useTranslation } from 'react-i18next'
+import { useConfigState } from '~/hooks'
+import { filterGames, sortGames } from '~/stores/game'
+import { cn } from '~/utils'
+import { useFilterStore } from '../Filter/store'
+import { GameNav } from '../GameNav'
 
 export function FilterGame(): JSX.Element {
+  const [by, _setBy] = useConfigState('game.gameList.sort.by')
+  const [order, _setOrder] = useConfigState('game.gameList.sort.order')
   const { filter } = useFilterStore()
-  const games = filterGames(filter)
+  const games = sortGames(by, order, filterGames(filter))
   const { t } = useTranslation('game')
   return (
     <ScrollArea className={cn('w-full h-full pr-3 -mr-3')}>

--- a/src/renderer/src/components/Librarybar/GameList/Others.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/Others.tsx
@@ -1,14 +1,14 @@
-import { cn } from '~/utils'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@ui/accordion'
-import { ScrollArea } from '@ui/scroll-area'
-import { ContextMenuContent, ContextMenuTrigger, ContextMenu } from '@ui/context-menu'
 import { Button } from '@ui/button'
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '@ui/context-menu'
+import { ScrollArea } from '@ui/scroll-area'
+import { useTranslation } from 'react-i18next'
 import { useConfigState } from '~/hooks'
-import { getAllValuesInKey, filterGames } from '~/stores/game'
+import { filterGames, getAllValuesInKey, sortGames } from '~/stores/game'
+import { cn } from '~/utils'
 import { GameNav } from '../GameNav'
 import { AllGame } from './AllGame'
 import { RecentGames } from './RecentGames'
-import { useTranslation } from 'react-i18next'
 
 export function Others({
   fieldName
@@ -16,6 +16,8 @@ export function Others({
   fieldName: 'metadata.developers' | 'metadata.genres' | 'record.playStatus'
 }): JSX.Element {
   const [playStatusOrder, setPlayStatusOrder] = useConfigState('game.gameList.playingStatusOrder')
+  const [by, _setBy] = useConfigState('game.gameList.sort.by')
+  const [order, _setOrder] = useConfigState('game.gameList.sort.order')
 
   const fields_tmp = getAllValuesInKey(fieldName)
   const fields =
@@ -121,7 +123,7 @@ export function Others({
                 </AccordionTrigger>
               )}
               <AccordionContent className={cn('rounded-none pt-1 flex flex-col gap-1')}>
-                {filterGames({ [fieldName]: [field] }).map((game) => (
+                {sortGames(by, order, filterGames({ [fieldName]: [field] })).map((game) => (
                   <GameNav key={game} gameId={game} groupId={`${fieldName}:${field}`} />
                 ))}
               </AccordionContent>

--- a/src/renderer/src/components/Librarybar/GameList/Search.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/Search.tsx
@@ -1,13 +1,16 @@
-import { searchGames } from '~/stores/game'
-import { cn } from '~/utils'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@ui/accordion'
 import { ScrollArea } from '@ui/scroll-area'
-import { GameNav } from '../GameNav'
 import { useTranslation } from 'react-i18next'
+import { useConfigState } from '~/hooks'
+import { searchGames, sortGames } from '~/stores/game'
+import { cn } from '~/utils'
+import { GameNav } from '../GameNav'
 
 export function Search({ query }: { query: string }): JSX.Element {
+  const [by, _setBy] = useConfigState('game.gameList.sort.by')
+  const [order, _setOrder] = useConfigState('game.gameList.sort.order')
   const { t } = useTranslation('game')
-  const games = searchGames(query)
+  const games = sortGames(by, order, searchGames(query))
   return (
     <ScrollArea className={cn('w-full h-full pr-3 -mr-3')}>
       <Accordion

--- a/src/renderer/src/components/Librarybar/main.tsx
+++ b/src/renderer/src/components/Librarybar/main.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@ui/button'
 import { Input } from '@ui/input'
 import { Nav } from '@ui/nav'
+import { Popover, PopoverContent, PopoverTrigger } from '@ui/popover'
 import {
   Select,
   SelectContent,
@@ -12,6 +13,7 @@ import {
 } from '@ui/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@ui/tooltip'
 import { isEqual } from 'lodash'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useConfigState } from '~/hooks'
 import { cn } from '~/utils'
@@ -29,6 +31,16 @@ export function Librarybar(): JSX.Element {
   const filter = useFilterStore((state) => state.filter)
   const toggleFilterMenu = useFilterStore((state) => state.toggleFilterMenu)
   const clearFilter = useFilterStore((state) => state.clearFilter)
+
+  const [isSortMenuOpen, setIsSortMenuOpen] = useState(false)
+  const [by, setBy] = useConfigState('game.gameList.sort.by')
+  const [order, setOrder] = useConfigState('game.gameList.sort.order')
+  const toggleSortMenu = (): void => {
+    setIsSortMenuOpen(!isSortMenuOpen)
+  }
+  const toggleOrder = (): void => {
+    setOrder(order === 'asc' ? 'desc' : 'asc')
+  }
 
   console.warn(`[DEBUG] Librarybar`)
 
@@ -103,26 +115,86 @@ export function Librarybar(): JSX.Element {
             )}
           </div>
         </div>
-        <div className={cn('pr-3')}>
-          <Select value={selectedGroup} onValueChange={setSelectedGroup}>
-            <SelectTrigger className="pr-3">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                <SelectLabel>{t('librarybar.groupBy')}</SelectLabel>
-                <SelectItem value="none">{t('librarybar.groups.none')}</SelectItem>
-                <SelectItem value="collection">{t('librarybar.groups.collection')}</SelectItem>
-                <SelectItem value="metadata.developers">
-                  {t('librarybar.groups.developers')}
-                </SelectItem>
-                <SelectItem value="metadata.genres">{t('librarybar.groups.genres')}</SelectItem>
-                <SelectItem value="record.playStatus">
-                  {t('librarybar.groups.playStatus')}
-                </SelectItem>
-              </SelectGroup>
-            </SelectContent>
-          </Select>
+        <div className={cn('flex flex-row gap-2 pr-3 items-center')}>
+          <div className={cn('flex-1 min-w-0')}>
+            <Select value={selectedGroup} onValueChange={setSelectedGroup}>
+              <SelectTrigger className="pr-3">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectLabel>{t('librarybar.groupBy')}</SelectLabel>
+                  <SelectItem value="none">{t('librarybar.groups.none')}</SelectItem>
+                  <SelectItem value="collection">{t('librarybar.groups.collection')}</SelectItem>
+                  <SelectItem value="metadata.developers">
+                    {t('librarybar.groups.developers')}
+                  </SelectItem>
+                  <SelectItem value="metadata.genres">{t('librarybar.groups.genres')}</SelectItem>
+                  <SelectItem value="record.playStatus">
+                    {t('librarybar.groups.playStatus')}
+                  </SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Popover open={isSortMenuOpen}>
+              <Tooltip>
+                <PopoverTrigger>
+                  <TooltipTrigger asChild>
+                    <Button onClick={toggleSortMenu} variant="outline" size={'icon'}>
+                      <span className={cn('icon-[mdi--sort] w-5 h-5')}></span>
+                    </Button>
+                  </TooltipTrigger>
+                </PopoverTrigger>
+                <TooltipContent side="right">{t('list.all.sortBy')}</TooltipContent>
+              </Tooltip>
+              <PopoverContent side="right">
+                <div className={cn('flex flex-row gap-5 items-center justify-center')}>
+                  <div className={cn('flex flex-row gap-1 items-center justify-center')}>
+                    <div className={cn('text-sm whitespace-nowrap')}>{t('list.all.sortBy')}：</div>
+                    <Select value={by} onValueChange={setBy} defaultValue="name">
+                      <SelectTrigger className={cn('w-[120px] h-[26px] text-xs')}>
+                        <SelectValue placeholder="Select a fruit" className={cn('text-xs')} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          <SelectLabel>{t('list.all.sortBy')}：</SelectLabel>
+                          <SelectItem value="metadata.name">
+                            {t('list.all.sortOptions.name')}
+                          </SelectItem>
+                          <SelectItem value="metadata.releaseDate">
+                            {t('list.all.sortOptions.releaseDate')}
+                          </SelectItem>
+                          <SelectItem value="record.lastRunDate">
+                            {t('list.all.sortOptions.lastRunDate')}
+                          </SelectItem>
+                          <SelectItem value="record.addDate">
+                            {t('list.all.sortOptions.addDate')}
+                          </SelectItem>
+                          <SelectItem value="record.playTime">
+                            {t('list.all.sortOptions.playTime')}
+                          </SelectItem>
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <Button
+                    variant={'outline'}
+                    size={'icon'}
+                    className={cn('h-[26px] w-[26px] -ml-3')}
+                    onClick={toggleOrder}
+                  >
+                    {order === 'asc' ? (
+                      <span className={cn('icon-[mdi--arrow-up] w-4 h-4')}></span>
+                    ) : (
+                      <span className={cn('icon-[mdi--arrow-down] w-4 h-4')}></span>
+                    )}
+                  </Button>
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
         </div>
         <GameList query={query} selectedGroup={selectedGroup} />
       </div>

--- a/src/renderer/src/stores/game/gameUtils.ts
+++ b/src/renderer/src/stores/game/gameUtils.ts
@@ -1,10 +1,10 @@
-import { calculateDailyPlayTime } from '@appUtils'
-import { getGameStore } from './gameStoreFactory'
-import { useGameRegistry } from './gameRegistry'
-import { useConfigStore } from '../config'
 import type { MaxPlayTimeDay, gameDoc } from '@appTypes/database'
-import type { Paths } from 'type-fest'
+import { calculateDailyPlayTime } from '@appUtils'
 import i18next from 'i18next'
+import type { Paths } from 'type-fest'
+import { useConfigStore } from '../config'
+import { useGameRegistry } from './gameRegistry'
+import { getGameStore } from './gameStoreFactory'
 
 // Search Functions
 export function searchGames(query: string): string[] {
@@ -46,9 +46,10 @@ export function searchGames(query: string): string[] {
 // sorting function
 export function sortGames<Path extends Paths<gameDoc, { bracketNotation: true }>>(
   by: Path,
-  order: 'asc' | 'desc' = 'asc'
+  order: 'asc' | 'desc' = 'asc',
+  gameIds?: string[]
 ): string[] {
-  const gameIds = useGameRegistry.getState().gameIds
+  if (!gameIds) gameIds = useGameRegistry.getState().gameIds
   const language = useConfigStore.getState().getConfigValue('general.language')
 
   return [...gameIds].sort((a, b) => {


### PR DESCRIPTION
- 把原先侧栏中`所有游戏`右键开启的排序方式设置窗口移动到了外面
- 把这个排序应用到了筛选、查询、按游戏状态/类型/开发商分组的游戏展示中，共用一套设置
- 考虑到收藏夹内部游戏是有序的，就没有给收藏夹应用这个设置。如果要给它应用的话或许还要加一个是否覆盖原有排序的开关