### PR TITLE
fix: Fixed the wrong time zone conversion and week calculation on the record page

### DIFF
--- a/src/renderer/src/stores/game/recordUtils.ts
+++ b/src/renderer/src/stores/game/recordUtils.ts
@@ -1,6 +1,6 @@
-import { getGameStore, useGameRegistry } from '~/stores/game'
 import type { gameDoc } from '@appTypes/database'
 import i18next from 'i18next'
+import { getGameStore, useGameRegistry } from '~/stores/game'
 
 interface WeeklyMostPlayedDay {
   date: string
@@ -184,9 +184,10 @@ export function getMonthlyPlayData(date = new Date()): {
       let dayTotal = 0
 
       // Calculate what week of the month the current date is
-      const weekOfMonth = Math.ceil(
-        (dayDate.getDate() + new Date(dayDate.getFullYear(), dayDate.getMonth(), 1).getDay()) / 7
-      )
+      const firstWeek = 1 // set the first day of the week to Monday (0-Sun, 1-Mon, ...)
+      const weekOfFirstDay =
+        (new Date(dayDate.getFullYear(), dayDate.getMonth(), 1).getDay() - firstWeek + 7) % 7
+      const weekOfMonth = Math.ceil((dayDate.getDate() + weekOfFirstDay) / 7)
 
       // Iterate through all the games
       for (const gameId of gameIds) {


### PR DESCRIPTION
- 在月度报告中，星期日被当作了一周的第一天，将其修改为了周一
- 在周度报告中，能否切换到下一周的判断有误，在周日就可以切换到下一周（因为判断用的weekEnd实际上是最后一天的开始而不是结束）
- 在周度报告中，使用上游函数传递过来的日期字符串初始化Date对象时，`Date(str)`错误地将本地时区的日期初始化为了UTC对应日期的0点，在负数时区中会导致日期的错位