### PR TITLE
fix the wrong input layout in RelatedSitesDialog

### DIFF
--- a/src/renderer/src/components/Librarybar/main.tsx
+++ b/src/renderer/src/components/Librarybar/main.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@ui/button'
-import { Input } from '@ui/input'
+import { ClearableInput } from '@ui/input'
 import { Nav } from '@ui/nav'
 import { Popover, PopoverContent, PopoverTrigger } from '@ui/popover'
 import {
@@ -83,11 +83,10 @@ export function Librarybar(): JSX.Element {
           <div className={cn('grow')}>
             <Tooltip>
               <TooltipTrigger className={cn('w-full')}>
-                <Input
+                <ClearableInput
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   placeholder={t('librarybar.search.placeholder')}
-                  showClear={true}
                   onClear={() => setQuery('')}
                 />
               </TooltipTrigger>

--- a/src/renderer/src/components/ui/input.tsx
+++ b/src/renderer/src/components/ui/input.tsx
@@ -4,13 +4,37 @@ import { Button } from './button'
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   variant?: 'default' | 'ghost'
-  showClear?: boolean
+}
+
+export interface ClearableInputProps extends InputProps {
+  inputClassName?: string
   onClear?: () => void
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, variant = 'default', value, onChange, ...props }, ref) => {
+    return (
+      <input
+        spellCheck="false"
+        type={type}
+        className={cn(
+          'flex h-9 w-full non-draggable rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+          variant === 'ghost' &&
+            'border-0 bg-transparent hover:bg-accent transition-none focus:hover:bg-transparent truncate shadow-none',
+          className
+        )}
+        value={value}
+        onChange={onChange}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+
+const ClearableInput = React.forwardRef<HTMLInputElement, ClearableInputProps>(
   (
-    { className, type, variant = 'default', showClear = false, onClear, value, onChange, ...props },
+    { className, inputClassName, type, variant = 'default', onClear, value, onChange, ...props },
     ref
   ) => {
     // Handle clearing input content
@@ -32,24 +56,18 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     }
 
     // Check if clear button should be shown
-    const hasValue = value !== undefined && value !== null && value !== ''
-    const showClearButton = showClear && hasValue
+    const hasValue = Boolean(value)
+    const showClearButton = hasValue
 
     return (
-      <div className="relative w-full">
-        <input
-          spellCheck="false"
+      <div className={cn('relative w-full', className)}>
+        <Input
           type={type}
-          className={cn(
-            'flex h-9 w-full non-draggable rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
-            variant === 'ghost' &&
-              'border-0 bg-transparent hover:bg-accent transition-none focus:hover:bg-transparent truncate shadow-none',
-            showClearButton ? 'pr-8' : '',
-            className
-          )}
+          className={cn(showClearButton ? 'pr-8' : '', inputClassName)}
           value={value}
           onChange={onChange}
           ref={ref}
+          variant={variant}
           {...props}
         />
         {showClearButton && (
@@ -68,5 +86,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 )
 
 Input.displayName = 'Input'
+ClearableInput.displayName = 'ClearableInput'
 
-export { Input }
+export { ClearableInput, Input }


### PR DESCRIPTION
主要是为了修复相关网站编辑窗口输入框尺寸变得奇怪的问题。

发现是给<Input>添加清除按钮之后外面多套了一层<div>，然后这里className就没有应用到最上层。又看了一下其他用到<Input>的地方传的flex/grow之类的东西貌似理论上也要应用到最上层（虽然没见出问题，误打误撞吧应该是），干脆把带清除按钮的输入框独立出来了。