### PR TITLE
fix: Optimized drag-and-drop display

### DIFF
--- a/src/renderer/src/components/Showcase/Collections.tsx
+++ b/src/renderer/src/components/Showcase/Collections.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@ui/button'
 import { throttle } from 'lodash'
 import { useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useGameCollectionStore } from '~/stores'
 import { cn } from '~/utils'
 import { CollectionPoster } from './posters/CollectionPoster'
-import { useTranslation } from 'react-i18next'
 
 export function Collections(): JSX.Element {
   const collections = useGameCollectionStore((state) => state.documents)
@@ -72,6 +72,7 @@ export function Collections(): JSX.Element {
           >
             <CollectionPoster
               collectionId={collectionId}
+              parentGap={32} // Gap(px) between posters
               position={
                 (index === 0 && 'left') ||
                 (index === Object.keys(collections).length - 1 && 'right') ||

--- a/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
@@ -22,10 +22,12 @@ import {
 
 function Preview({
   collectionName,
-  collectionLength
+  collectionLength,
+  transparentBackground = false
 }: {
   collectionName: string
   collectionLength: number
+  transparentBackground?: boolean
 }): JSX.Element {
   return (
     <div
@@ -33,7 +35,8 @@ function Preview({
         'group relative overflow-hidden w-[150px] h-[150px] rounded-lg',
         'transition-all duration-300 ease-in-out',
         // '3xl:w-[180px] 3xl:h-[180px]',
-        'border-4 border-dashed border-primary bg-background'
+        'border-4 border-dashed border-primary',
+        !transparentBackground && ' bg-background'
       )}
     >
       <div
@@ -60,8 +63,8 @@ export function CollectionPoster({
 }: {
   collectionId: string
   className?: string
-  parentGap?: number
-  position?: 'right' | 'left' | 'center'
+  parentGap?: number // Gap(px) between posters
+  position?: 'right' | 'left' | 'center' // poster position in the container
 }): JSX.Element {
   const navigate = useNavigate()
   const collections = useGameCollectionStore((state) => state.documents)
@@ -131,7 +134,11 @@ export function CollectionPoster({
     <CollectionCM collectionId={collectionId}>
       <div className={cn('group relative rounded-lg')} ref={ref_}>
         {dragging ? (
-          <Preview collectionLength={length} collectionName={collectionName} />
+          <Preview
+            collectionLength={length}
+            collectionName={collectionName}
+            transparentBackground={true}
+          />
         ) : (
           <div
             className={cn(

--- a/src/renderer/src/components/Showcase/posters/GamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/GamePoster.tsx
@@ -1,16 +1,19 @@
+import { generateUUID } from '@appUtils'
 import { ContextMenu, ContextMenuTrigger } from '@ui/context-menu'
 import { GameImage } from '@ui/game-image'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@ui/hover-card'
 import { MutableRefObject, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { HoverCardAnimation } from '~/components/animations/HoverCard'
 import { GameNavCM } from '~/components/contextMenu/GameNavCM'
 import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
 import { NameEditorDialog } from '~/components/Game/Config/ManageMenu/NameEditorDialog'
 import { PlayTimeEditorDialog } from '~/components/Game/Config/ManageMenu/PlayTimeEditorDialog'
+import { usePositionButtonStore } from '~/components/Librarybar/PositionButton'
 import { useDragContext } from '~/components/Showcase/CollectionGames'
 import { useGameState } from '~/hooks'
-import { useGameRegistry, useGameCollectionStore } from '~/stores/game'
+import { useGameCollectionStore, useGameRegistry } from '~/stores/game'
 import { cn, scrollToElement } from '~/utils'
 import {
   attachClosestEdge,
@@ -26,17 +29,21 @@ import {
   type Edge,
   type PreviewState
 } from '~/utils/dnd-utills'
-import { useTranslation } from 'react-i18next'
-import { usePositionButtonStore } from '~/components/Librarybar/PositionButton'
-import { generateUUID } from '@appUtils'
 
-function Preview({ title }: { title: string }): JSX.Element {
+function Preview({
+  title,
+  transparentBackground = false
+}: {
+  title: string
+  transparentBackground?: boolean
+}): JSX.Element {
   return (
     <div
       className={cn(
         'relative w-[150px] aspect-[2/3] rounded-lg',
         '3xl:w-[176px] 3xl:h-[264px]',
-        'border-4 border-dashed border-primary bg-background'
+        'border-4 border-dashed border-primary',
+        !transparentBackground && ' bg-background'
       )}
     >
       <div
@@ -189,7 +196,7 @@ export function GamePoster({
   return (
     <div ref={ref_} className="relative overflow-visible">
       {dragging ? (
-        <Preview title={gameData?.name ?? ''} />
+        <Preview title={gameData?.name ?? ''} transparentBackground={true} />
       ) : (
         <HoverCard open={isOpen && !isDraggingGlobal}>
           <ContextMenu>

--- a/src/renderer/src/pages/DragContainer.tsx
+++ b/src/renderer/src/pages/DragContainer.tsx
@@ -1,12 +1,11 @@
-import { cn } from '~/utils'
-import { useState, useEffect } from 'react'
+import { generateUUID } from '@appUtils'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { useConfigState } from '~/hooks'
+import { cn, ipcInvoke } from '~/utils'
 import { useGameAdderStore } from './GameAdder/store'
 import { useGameBatchAdderStore } from './GameBatchAdder/store'
-import { ipcInvoke } from '~/utils'
-import { generateUUID } from '@appUtils'
-import { useConfigState } from '~/hooks'
-import { toast } from 'sonner'
-import { useTranslation } from 'react-i18next'
 
 export function DragContainer({ children }: { children: React.ReactNode }): JSX.Element {
   const { t } = useTranslation('sidebar')
@@ -14,25 +13,42 @@ export function DragContainer({ children }: { children: React.ReactNode }): JSX.
   const { setIsOpen: setGameAdderIsOpen, setName, setDirPath } = useGameAdderStore()
   const { actions: gameBatchAdderActions } = useGameBatchAdderStore()
   const [defaultDataSource] = useConfigState('game.scraper.defaultDatasSource')
+
+  const isFileDrag = (event: DragEvent): boolean => {
+    if (!event.dataTransfer) return false
+
+    const types = Array.from(event.dataTransfer.types)
+    // `types.includes('Files')` doesn't work when dragging img element
+    if (types.length === 1 && types[0] === 'Files') {
+      return true
+    }
+
+    return false
+  }
+
   useEffect(() => {
     const handleDragEnter = (event: DragEvent): void => {
       event.preventDefault()
       event.stopPropagation()
+      if (!isFileDrag(event)) return
       setIsDragging(true)
     }
     const handleDragOver = (event: DragEvent): void => {
       event.preventDefault()
       event.stopPropagation()
+      if (!isFileDrag(event)) return
       setIsDragging(true)
     }
     const handleDragLeave = (event: DragEvent): void => {
       event.preventDefault()
       event.stopPropagation()
+      if (!isFileDrag(event)) return
       setIsDragging(false)
     }
     const handleDrop = async (event: DragEvent): Promise<void> => {
       event.preventDefault()
       event.stopPropagation()
+      if (!isFileDrag(event)) return
       setIsDragging(false)
 
       const paths = event.dataTransfer?.files


### PR DESCRIPTION
优化了拖拽相关的若干样式问题：
1. 对于从外部添加文件的拖拽功能，添加了过滤条件，避免软件内部拖拽事件触发阴影蒙版
2. 对于主页中收藏夹的拖拽排序，修复了因为gap值调整而歪掉不在正中间的拖拽指示器
3. 优化了收藏夹海报与游戏海报的拖拽预览样式，使其能够透出下方背景