### PR TITLE
fix: Optimized display in the games-of-collection page

### DIFF
--- a/src/renderer/src/components/Showcase/CollectionGames.tsx
+++ b/src/renderer/src/components/Showcase/CollectionGames.tsx
@@ -1,9 +1,9 @@
 import { ScrollArea } from '@ui/scroll-area'
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
+import { LazyLoadComponent, trackWindowScroll } from 'react-lazy-load-image-component'
 import { useGameCollectionStore } from '~/stores'
 import { cn } from '~/utils'
 import { GamePoster } from './posters/GamePoster'
-import { LazyLoadComponent, trackWindowScroll } from 'react-lazy-load-image-component'
 
 export type DragContextType = {
   isDraggingGlobal: boolean
@@ -121,6 +121,9 @@ export function CollectionGamesComponent({
             </div>
           </div>
         </ScrollArea>
+        {/* This spacer prevents the last row of posters from being cut off 
+        and enables downward auto-scrolling when dragging near the bottom. */}
+        <div className="h-10" />
       </div>
     </DragContext.Provider>
   )

--- a/src/renderer/src/components/Showcase/posters/GamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/GamePoster.tsx
@@ -40,8 +40,7 @@ function Preview({
   return (
     <div
       className={cn(
-        'relative w-[150px] aspect-[2/3] rounded-lg',
-        '3xl:w-[176px] 3xl:h-[264px]',
+        'relative w-[148px] aspect-[2/3] rounded-lg',
         'border-4 border-dashed border-primary',
         !transparentBackground && ' bg-background'
       )}


### PR DESCRIPTION
主要修复展示某一收藏中游戏海报时的样式问题：
- 最底部一行的海报无法显示完全，存在小部分遮挡
- 修改了海报尺寸后没有同步修改预览样式的尺寸，导致其稍大一圈，在显示时会在纵向挤开其他行