### PR TITLE
Optimize tooltips

### DIFF
--- a/src/renderer/locales/en/scanner.json
+++ b/src/renderer/locales/en/scanner.json
@@ -54,6 +54,11 @@
         "description": "Are you sure you want to delete the scan directory \"{{path}}\"? This action cannot be undone.",
         "cancel": "Cancel",
         "confirm": "Confirm Delete"
+      },
+      "tooltips": {
+        "scan": "Scan",
+        "edit": "Edit",
+        "delete": "Delete"
       }
     }
   },

--- a/src/renderer/locales/en/transformer.json
+++ b/src/renderer/locales/en/transformer.json
@@ -71,7 +71,12 @@
     "noResults": "No presets found"
   },
   "transformerItem": {
-    "rulesCount": "{{count}} rules"
+    "rulesCount": "{{count}} rules",
+    "tooltips":{
+      "edit": "Edit",
+      "export": "Export",
+      "delete": "Delete"
+    }
   },
   "presets": {
     "vndbChineseTags": {

--- a/src/renderer/locales/zh-CN/scanner.json
+++ b/src/renderer/locales/zh-CN/scanner.json
@@ -54,6 +54,11 @@
         "description": "确定要删除扫描目录\"{{path}}\"吗？此操作无法撤销。",
         "cancel": "取消",
         "confirm": "确认删除"
+      },
+      "tooltips": {
+        "scan": "启动扫描",
+        "edit": "编辑",
+        "delete": "删除"
       }
     }
   },

--- a/src/renderer/locales/zh-CN/transformer.json
+++ b/src/renderer/locales/zh-CN/transformer.json
@@ -71,7 +71,12 @@
     "noResults": "未找到预设"
   },
   "transformerItem": {
-    "rulesCount": "{{count}} 条规则"
+    "rulesCount": "{{count}} 条规则",
+    "tooltips":{
+      "edit": "编辑",
+      "export": "导出",
+      "delete": "删除"
+    }
   },
   "presets": {
     "vndbChineseTags": {

--- a/src/renderer/src/pages/GameScannerManager/FailedFoldersDialog.tsx
+++ b/src/renderer/src/pages/GameScannerManager/FailedFoldersDialog.tsx
@@ -1,13 +1,14 @@
+import { Button } from '@ui/button'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@ui/dialog'
+import { Input } from '@ui/input'
+import { ScrollArea } from '@ui/scroll-area'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@ui/table'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@ui/tooltip'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@ui/dialog'
-import { Input } from '@ui/input'
-import { Button } from '@ui/button'
-import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@ui/table'
-import { useGameScannerStore } from './store'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@ui/select'
-import { ScrollArea } from '@ui/scroll-area'
 import { cn } from '~/utils'
+import { useGameScannerStore } from './store'
 
 interface FailedFoldersDialogProps {
   isOpen: boolean
@@ -123,7 +124,7 @@ export const FailedFoldersDialog: React.FC<FailedFoldersDialogProps> = ({ isOpen
                 <p className="font-medium">
                   {t('failedFolders.fixing', { name: selectedFolder.name })}
                 </p>
-                <p className="text-sm">{selectedFolder.error}</p>
+                <p className="text-sm text-destructive">{selectedFolder.error}</p>
               </div>
 
               <div className="grid grid-cols-[auto_1fr] gap-y-4 gap-x-4 items-center">
@@ -175,11 +176,21 @@ export const FailedFoldersDialog: React.FC<FailedFoldersDialogProps> = ({ isOpen
                   {failedFolders.map((folder, index) => (
                     <TableRow key={index}>
                       <TableCell className="font-medium">{folder.name}</TableCell>
-                      <TableCell className="text-xs truncate max-w-[200px]">
-                        {folder.path.split('/').pop()}
+                      <TableCell className="max-w-[200px]">
+                        <Tooltip>
+                          <TooltipTrigger className="text-xs truncate max-w-[200px]">
+                            {folder.path.split('/').pop()}
+                          </TooltipTrigger>
+                          <TooltipContent>{folder.path.split('/').pop()}</TooltipContent>
+                        </Tooltip>
                       </TableCell>
-                      <TableCell className="text-xs truncate max-w-[200px]">
-                        {folder.error}
+                      <TableCell className="max-w-[200px]">
+                        <Tooltip>
+                          <TooltipTrigger className="text-xs truncate max-w-[200px]">
+                            {folder.error}
+                          </TooltipTrigger>
+                          <TooltipContent>{folder.error}</TooltipContent>
+                        </Tooltip>
                       </TableCell>
                       <TableCell className="flex flex-row">
                         <Button

--- a/src/renderer/src/pages/GameScannerManager/GameScannerListItem.tsx
+++ b/src/renderer/src/pages/GameScannerManager/GameScannerListItem.tsx
@@ -1,8 +1,3 @@
-import React, { useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Button } from '@ui/button'
-import { Badge } from '@ui/badge'
-import { Folder, Pencil, Trash2, PlayCircle } from 'lucide-react'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,9 +8,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle
 } from '@ui/alert-dialog'
+import { Badge } from '@ui/badge'
+import { Button } from '@ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@ui/tooltip'
+import { Folder, Pencil, PlayCircle, Trash2 } from 'lucide-react'
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useConfigLocalState } from '~/hooks'
-import { useGameScannerStore } from './store'
 import { cn } from '~/utils'
+import { useGameScannerStore } from './store'
 
 interface GameScannerListItemProps {
   scanner: {
@@ -146,31 +147,48 @@ export const GameScannerListItem: React.FC<GameScannerListItemProps> = ({
         <Badge variant={variant}>{label}</Badge>
 
         <div className="flex gap-1 ml-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleScan}
-            disabled={scanProgress.status === 'scanning' || isScanning}
-          >
-            <PlayCircle className="w-4 h-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            disabled={scanProgress.status === 'scanning' || isScanning}
-            onClick={onEditClick}
-          >
-            <Pencil className="w-4 h-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => setShowDeleteDialog(true)}
-            className="hover:text-destructive"
-            disabled={scanProgress.status === 'scanning' || isScanning}
-          >
-            <Trash2 className="w-4 h-4" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleScan}
+                disabled={scanProgress.status === 'scanning' || isScanning}
+              >
+                <PlayCircle className="w-4 h-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{t('list.item.tooltips.scan')}</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant="ghost"
+                size="icon"
+                disabled={scanProgress.status === 'scanning' || isScanning}
+                onClick={onEditClick}
+              >
+                <Pencil className="w-4 h-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{t('list.item.tooltips.edit')}</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setShowDeleteDialog(true)}
+                className="hover:text-destructive"
+                disabled={scanProgress.status === 'scanning' || isScanning}
+              >
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{t('list.item.tooltips.delete')}</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/src/renderer/src/pages/TransformerManager/TransformerItem.tsx
+++ b/src/renderer/src/pages/TransformerManager/TransformerItem.tsx
@@ -1,11 +1,11 @@
-import { Badge } from '@ui/badge'
-import { TransformerRule } from './types'
-import { Button } from '@ui/button'
-import { cn } from '~/utils'
-import { useTranslation } from 'react-i18next'
-import { ipcInvoke } from '~/utils'
-import { toast } from 'sonner'
 import { getErrorMessage } from '@appUtils'
+import { Badge } from '@ui/badge'
+import { Button } from '@ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@ui/tooltip'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { cn, ipcInvoke } from '~/utils'
+import { TransformerRule } from './types'
 
 interface TransformerItemProps {
   transformer: TransformerRule
@@ -66,7 +66,7 @@ export function TransformerItem({
           </div>
         </div>
 
-        <div className="flex items-center space-x-2" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
           <Button
             className={cn(index === 0 && 'opacity-50 cursor-not-allowed')}
             variant={'ghost'}
@@ -87,17 +87,37 @@ export function TransformerItem({
             <span className="w-4 h-4 icon-[mdi--chevron-down]"></span>
           </Button>
 
-          <Button variant="ghost" onClick={() => onEditClick(transformer)} size={'icon'}>
-            <span className="w-4 h-4 icon-[mdi--pencil]"></span>
-          </Button>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button variant="ghost" onClick={() => onEditClick(transformer)} size={'icon'}>
+                <span className="w-4 h-4 icon-[mdi--pencil]"></span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{t('transformerItem.tooltips.edit')}</TooltipContent>
+          </Tooltip>
 
-          <Button variant="ghost" onClick={handleExport} size={'icon'}>
-            <span className="w-4 h-4 icon-[mdi--export]"></span>
-          </Button>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button variant="ghost" onClick={handleExport} size={'icon'}>
+                <span className="w-4 h-4 icon-[mdi--export]"></span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{t('transformerItem.tooltips.export')}</TooltipContent>
+          </Tooltip>
 
-          <Button variant={'ghost'} size={'icon'} onClick={() => onDeleteClick(transformer)}>
-            <span className="w-4 h-4 icon-[mdi--delete-outline]"></span>
-          </Button>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant={'ghost'}
+                size={'icon'}
+                className="hover:text-destructive"
+                onClick={() => onDeleteClick(transformer)}
+              >
+                <span className="w-4 h-4 icon-[mdi--delete-outline]"></span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{t('transformerItem.tooltips.delete')}</TooltipContent>
+          </Tooltip>
         </div>
       </div>
     </div>


### PR DESCRIPTION
添加了扫描器的提示：
- 对主页面三个没有文字的按钮，增加了悬浮提示
- 对纠错弹窗中的路径与错误信息，因为可能被省略，增加了悬浮提示
- 将修复弹窗中的错误信息换成了红色，增加对比度

添加了转换器的提示：
- 对主页面三个没有文字的按钮，增加了提示

> 语言文件加起来好麻烦，先空着到时候去网站上整好了