### PR TITLE
Optimize transformer manager‘s rule dialog

### DIFF
--- a/src/renderer/locales/en/transformer.json
+++ b/src/renderer/locales/en/transformer.json
@@ -18,6 +18,7 @@
   "ruleDialog": {
     "title": "Rule Settings",
     "loading": "Loading…",
+    "noRules": "No rules yet",
     "categories": {
       "name": "Name",
       "originalName": "Original Name",

--- a/src/renderer/locales/zh-CN/transformer.json
+++ b/src/renderer/locales/zh-CN/transformer.json
@@ -18,6 +18,7 @@
   "ruleDialog": {
     "title": "规则设置",
     "loading": "加载中…",
+    "noRules": "暂无规则",
     "categories": {
       "name": "译名",
       "originalName": "原名",

--- a/src/renderer/src/pages/TransformerManager/RuleDialog.tsx
+++ b/src/renderer/src/pages/TransformerManager/RuleDialog.tsx
@@ -176,23 +176,29 @@ export function RuleDialog({
 
         {currentRuleCategory === category && (
           <div className="flex-grow">
-            <AutoSizer>
-              {({ height, width }) => {
-                return (
-                  <FixedSizeList
-                    className="scrollbar-base-thin"
-                    height={height}
-                    width={width}
-                    itemCount={rules.length}
-                    itemSize={50}
-                    layout="vertical"
-                    style={{ willChange: 'auto' }} // fix: the content becomes blurred when custom scrollbar appears
-                  >
-                    {Row}
-                  </FixedSizeList>
-                )
-              }}
-            </AutoSizer>
+            {rules.length !== 0 ? (
+              <AutoSizer>
+                {({ height, width }) => {
+                  return (
+                    <FixedSizeList
+                      className="scrollbar-base-thin"
+                      height={height}
+                      width={width}
+                      itemCount={rules.length}
+                      itemSize={50}
+                      layout="vertical"
+                      style={{ willChange: 'auto' }} // fix: the content becomes blurred when custom scrollbar appears
+                    >
+                      {Row}
+                    </FixedSizeList>
+                  )
+                }}
+              </AutoSizer>
+            ) : (
+              <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+                {t('ruleDialog.noRules')}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/renderer/src/pages/TransformerManager/RuleDialog.tsx
+++ b/src/renderer/src/pages/TransformerManager/RuleDialog.tsx
@@ -1,12 +1,14 @@
-import React, { useState } from 'react'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@ui/dialog'
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@ui/accordion'
-import { Button } from '@ui/button'
-import { Input } from '@ui/input'
 import { ArrayEditor } from '@ui/array-editor'
-import { TransformerRule, RuleSet } from './types'
-import { Plus } from 'lucide-react'
+import { Button } from '@ui/button'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@ui/dialog'
+import { Input } from '@ui/input'
+import { ChevronDown, Plus } from 'lucide-react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import AutoSizer from 'react-virtualized-auto-sizer'
+import { FixedSizeList } from 'react-window'
+import { cn } from '~/utils'
+import { RuleSet, TransformerRule } from './types'
 
 interface RuleDialogProps {
   isOpen: boolean
@@ -23,6 +25,9 @@ export function RuleDialog({
 }: RuleDialogProps): JSX.Element {
   const { t } = useTranslation('transformer')
   const [localTransformer, setLocalTransformer] = useState<TransformerRule | null>(transformer)
+  const [currentRuleCategory, setCurrentRuleCategory] = useState<
+    keyof TransformerRule['processors'] | 'all'
+  >('all')
 
   // Update local state every time the dialog opens
   React.useEffect(() => {
@@ -107,48 +112,90 @@ export function RuleDialog({
     onOpenChange(false)
   }
 
-  // Render rule category content
-  const renderRuleCategory = (
+  const toggleCurrentRule = (to: keyof TransformerRule['processors']): void => {
+    if (currentRuleCategory === 'all') {
+      setCurrentRuleCategory(to)
+    } else {
+      setCurrentRuleCategory('all')
+    }
+  }
+
+  const ruleCategoryItem = (
     category: keyof TransformerRule['processors'],
     title: string
   ): JSX.Element => {
     const rules = localTransformer.processors[category] || []
 
-    return (
-      <AccordionItem value={category}>
-        <AccordionTrigger className="font-medium">{title}</AccordionTrigger>
-        <AccordionContent>
-          {rules.map((rule, index) => (
-            <div key={index} className="flex items-center gap-4 pt-1 mb-2">
-              <div className="w-[70%]">
-                <ArrayEditor
-                  value={rule.match}
-                  onChange={(value) => updateRuleSet(category, index, 'match', value)}
-                  placeholder={t('ruleDialog.match')}
-                  isHaveTooltip={true}
-                  dialogTitle={t('ruleDialog.addDialogTitle')}
-                  dialogPlaceholder={t('ruleDialog.addDialogPlaceholder')}
-                />
-              </div>
-              <div className="w-[calc(30%-68px)]">
-                <Input
-                  value={rule.replace}
-                  onChange={(e) => updateRuleSet(category, index, 'replace', e.target.value)}
-                  placeholder={t('ruleDialog.replace')}
-                />
-              </div>
-              <Button variant="outline" size="icon" onClick={() => deleteRule(category, index)}>
-                <span className="w-5 h-5 icon-[mdi--delete-outline]"></span>
-              </Button>
-            </div>
-          ))}
-
-          <Button variant="outline" size="sm" className="mt-2" onClick={() => addRule(category)}>
-            <Plus className="w-4 h-4 mr-2" />
-            {t('ruleDialog.addRule')}
+    const Row = ({ index, style }: { index: number; style: React.CSSProperties }): JSX.Element => {
+      const rule = rules[index]
+      return (
+        <div style={style} className={cn('flex items-center gap-4 pt-1 px-2')}>
+          <div className="flex-[7]">
+            <ArrayEditor
+              value={rule.match}
+              onChange={(value) => updateRuleSet(category, index, 'match', value)}
+              placeholder={t('ruleDialog.match')}
+              isHaveTooltip={true}
+              dialogTitle={t('ruleDialog.addDialogTitle')}
+              dialogPlaceholder={t('ruleDialog.addDialogPlaceholder')}
+            />
+          </div>
+          <div className="flex-[3]">
+            <Input
+              value={rule.replace}
+              onChange={(e) => updateRuleSet(category, index, 'replace', e.target.value)}
+              placeholder={t('ruleDialog.replace')}
+            />
+          </div>
+          <Button
+            variant="outline"
+            size="icon"
+            className="hover:text-destructive flex-shrink-0"
+            onClick={() => deleteRule(category, index)}
+          >
+            <span className="w-5 h-5 icon-[mdi--delete-outline]"></span>
           </Button>
-        </AccordionContent>
-      </AccordionItem>
+        </div>
+      )
+    }
+
+    return (
+      <div className={cn('flex flex-col w-full', currentRuleCategory === category && 'h-full')}>
+        <div
+          className="flex items-center px-4 py-3 cursor-pointer hover:bg-accent rounded-md transition"
+          onClick={() => toggleCurrentRule(category)}
+        >
+          <span className="text-sm font-medium text-foreground">{title}</span>
+          <div className="flex-grow" />
+          <ChevronDown
+            className={`w-4 h-4 text-muted-foreground transition-transform duration-200 ${
+              currentRuleCategory === category ? 'rotate-180' : ''
+            }`}
+          />
+        </div>
+
+        {currentRuleCategory === category && (
+          <div className="flex-grow">
+            <AutoSizer>
+              {({ height, width }) => {
+                return (
+                  <FixedSizeList
+                    className="scrollbar-base-thin"
+                    height={height}
+                    width={width}
+                    itemCount={rules.length}
+                    itemSize={50}
+                    layout="vertical"
+                    style={{ willChange: 'auto' }} // fix: the content becomes blurred when custom scrollbar appears
+                  >
+                    {Row}
+                  </FixedSizeList>
+                )
+              }}
+            </AutoSizer>
+          </div>
+        )}
+      </div>
     )
   }
 
@@ -161,24 +208,42 @@ export function RuleDialog({
           </DialogTitle>
         </DialogHeader>
         <div className="h-[calc(70vh-170px)] pr-2 overflow-y-auto scrollbar-base-thin">
-          <Accordion type="multiple" className="w-full">
-            {renderRuleCategory('name', t('ruleDialog.categories.name'))}
-            {renderRuleCategory('originalName', t('ruleDialog.categories.originalName'))}
-            {renderRuleCategory('description', t('ruleDialog.categories.description'))}
-            {renderRuleCategory('developers', t('ruleDialog.categories.developers'))}
-            {renderRuleCategory('publishers', t('ruleDialog.categories.publishers'))}
-            {renderRuleCategory('genres', t('ruleDialog.categories.genres'))}
-            {renderRuleCategory('platforms', t('ruleDialog.categories.platforms'))}
-            {renderRuleCategory('tags', t('ruleDialog.categories.tags'))}
-            {renderRuleCategory('director', t('ruleDialog.categories.director'))}
-            {renderRuleCategory('scenario', t('ruleDialog.categories.scenario'))}
-            {renderRuleCategory('illustration', t('ruleDialog.categories.illustration'))}
-            {renderRuleCategory('music', t('ruleDialog.categories.music'))}
-            {renderRuleCategory('engine', t('ruleDialog.categories.engine'))}
-          </Accordion>
+          <div className="w-full h-full">
+            {currentRuleCategory === 'all' ? (
+              <>
+                {ruleCategoryItem('name', t('ruleDialog.categories.name'))}
+                {ruleCategoryItem('originalName', t('ruleDialog.categories.originalName'))}
+                {ruleCategoryItem('description', t('ruleDialog.categories.description'))}
+                {ruleCategoryItem('developers', t('ruleDialog.categories.developers'))}
+                {ruleCategoryItem('publishers', t('ruleDialog.categories.publishers'))}
+                {ruleCategoryItem('genres', t('ruleDialog.categories.genres'))}
+                {ruleCategoryItem('platforms', t('ruleDialog.categories.platforms'))}
+                {ruleCategoryItem('tags', t('ruleDialog.categories.tags'))}
+                {ruleCategoryItem('director', t('ruleDialog.categories.director'))}
+                {ruleCategoryItem('scenario', t('ruleDialog.categories.scenario'))}
+                {ruleCategoryItem('illustration', t('ruleDialog.categories.illustration'))}
+                {ruleCategoryItem('music', t('ruleDialog.categories.music'))}
+                {ruleCategoryItem('engine', t('ruleDialog.categories.engine'))}
+              </>
+            ) : (
+              <>
+                {ruleCategoryItem(
+                  currentRuleCategory,
+                  t('ruleDialog.categories.' + currentRuleCategory)
+                )}
+              </>
+            )}
+          </div>
         </div>
 
         <DialogFooter>
+          {currentRuleCategory !== 'all' && (
+            <Button variant="outline" onClick={() => addRule(currentRuleCategory)}>
+              <Plus className="w-4 h-4 mr-2" />
+              {t('ruleDialog.addRule')}
+            </Button>
+          )}
+
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             {t('ruleDialog.cancel')}
           </Button>


### PR DESCRIPTION
### 修改内容
- [x] 改了一下布局，编辑起来应该能更顺手点
- [x] 给内容加虚拟列表

### 当前的问题
虽然已经用`react-window`把虚拟列表加上了，也能生效，但是渲染方面还有一些问题：
如果用`scrollbar-base`这些自定义的滑块样式，渲染的内容就会模糊（下有gif），原生的滑块就没问题
~~总之在考虑要不要换个虚拟列表的库试试（~~
**喜报，找到相关的issue与解法了**：https://github.com/bvaughn/react-window/issues/560

![GIF 2025-5-15 星期四 1-35-15](https://github.com/user-attachments/assets/34262477-71d2-41a3-937c-a114ee83404d)
