### PR TITLE
Fix

### DIFF
--- a/src/renderer/src/components/Game/Header.tsx
+++ b/src/renderer/src/components/Game/Header.tsx
@@ -89,14 +89,14 @@ export function Header({ gameId, className }: { gameId: string; className?: stri
       {/* Game name section */}
       <div className={cn('flex flex-col gap-3 grow overflow-hidden items-start justify-center')}>
         <div
-          className={cn('font-bold text-2xl text-accent-foreground cursor-pointer')}
+          className={cn('font-bold text-2xl text-accent-foreground cursor-pointer select-none')}
           onClick={() => copyWithToast(name)}
         >
           {name}
         </div>
         {showOriginalNameInGameHeader && originalName && originalName !== name && (
           <div
-            className={cn('font-bold text-accent-foreground cursor-pointer')}
+            className={cn('font-bold text-accent-foreground cursor-pointer select-none')}
             onClick={() => copyWithToast(originalName)}
           >
             {originalName}

--- a/src/renderer/src/components/Showcase/AllGames.tsx
+++ b/src/renderer/src/components/Showcase/AllGames.tsx
@@ -1,4 +1,3 @@
-import { cn } from '~/utils'
 import { Button } from '@ui/button'
 import {
   Select,
@@ -9,11 +8,12 @@ import {
   SelectTrigger,
   SelectValue
 } from '@ui/select'
+import { useTranslation } from 'react-i18next'
+import { LazyLoadComponent, trackWindowScroll } from 'react-lazy-load-image-component'
 import { useConfigState } from '~/hooks'
 import { sortGames } from '~/stores/game'
+import { cn } from '~/utils'
 import { GamePoster } from './posters/GamePoster'
-import { LazyLoadComponent, trackWindowScroll } from 'react-lazy-load-image-component'
-import { useTranslation } from 'react-i18next'
 
 function PlaceHolder(): JSX.Element {
   return (
@@ -37,10 +37,10 @@ export function AllGamesComponent({
     <div className={cn('w-full flex flex-col gap-1')}>
       <div className={cn('flex flex-row items-center gap-5 justify-center px-5')}>
         <div className={cn('flex flex-row gap-5 items-center justify-center')}>
-          <div className={cn('text-accent-foreground flex-shrink-0')}>
+          <div className={cn('text-accent-foreground select-none flex-shrink-0')}>
             {t('showcase.sections.allGames')}
           </div>
-          <div className={cn('flex flex-row gap-1 items-center justify-center')}>
+          <div className={cn('flex flex-row gap-1 items-center justify-center select-none')}>
             <div className={cn('text-sm')}>{t('showcase.sorting.title')}</div>
             <Select value={by} onValueChange={setBy} defaultValue="name">
               <SelectTrigger className={cn('w-[120px] h-[26px] text-xs')}>

--- a/src/renderer/src/components/Showcase/CollectionGames.tsx
+++ b/src/renderer/src/components/Showcase/CollectionGames.tsx
@@ -47,7 +47,7 @@ export function CollectionGamesComponent({
 
         const itemWidth = (gridItems[0] as HTMLDivElement).offsetWidth
         const containerStyle = window.getComputedStyle(gridContainer)
-        const minGap = parseFloat(containerStyle.getPropertyValue('gap'))
+        const minGap = parseFloat(containerStyle.getPropertyValue('column-gap'))
         const pL = parseFloat(containerStyle.paddingLeft)
         const pR = parseFloat(containerStyle.paddingRight)
 
@@ -123,7 +123,7 @@ export function CollectionGamesComponent({
         </ScrollArea>
         {/* This spacer prevents the last row of posters from being cut off
         and enables downward auto-scrolling when dragging near the bottom. */}
-        <div className="h-10" />
+        <div className="h-5" />
       </div>
     </DragContext.Provider>
   )

--- a/src/renderer/src/components/Showcase/CollectionGames.tsx
+++ b/src/renderer/src/components/Showcase/CollectionGames.tsx
@@ -78,7 +78,9 @@ export function CollectionGamesComponent({
         <ScrollArea className={cn('w-full')}>
           <div className={cn('w-full flex flex-col gap-1 pt-3')}>
             <div className={cn('flex flex-row items-center gap-5 justify-center pl-5')}>
-              <div className={cn('text-accent-foreground flex-shrink-0')}>{collectionName}</div>
+              <div className={cn('text-accent-foreground select-none flex-shrink-0')}>
+                {collectionName}
+              </div>
 
               {/* Split Line Container */}
               <div className={cn('flex items-center justify-center flex-grow')}>

--- a/src/renderer/src/components/Showcase/CollectionPage.tsx
+++ b/src/renderer/src/components/Showcase/CollectionPage.tsx
@@ -1,9 +1,9 @@
 import { ScrollArea } from '@ui/scroll-area'
 import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useGameCollectionStore } from '~/stores'
 import { cn } from '~/utils'
 import { CollectionPoster } from './posters/CollectionPoster'
-import { useTranslation } from 'react-i18next'
 
 export function CollectionPage(): JSX.Element {
   const collections = useGameCollectionStore((state) => state.documents)
@@ -19,7 +19,7 @@ export function CollectionPage(): JSX.Element {
         const gridItems = gridContainer.children
         const itemWidth = (gridItems[0] as HTMLDivElement).offsetWidth
         const containerStyle = window.getComputedStyle(gridContainer)
-        const minGap = parseFloat(containerStyle.getPropertyValue('gap'))
+        const minGap = parseFloat(containerStyle.getPropertyValue('column-gap'))
         const pL = parseFloat(containerStyle.paddingLeft)
         const pR = parseFloat(containerStyle.paddingRight)
 

--- a/src/renderer/src/components/Showcase/CollectionPage.tsx
+++ b/src/renderer/src/components/Showcase/CollectionPage.tsx
@@ -49,7 +49,7 @@ export function CollectionPage(): JSX.Element {
       <ScrollArea className={cn('w-full')}>
         <div className={cn('w-full flex flex-col gap-1 pt-3')}>
           <div className={cn('flex flex-row items-center gap-5 justify-center pl-5')}>
-            <div className={cn('text-accent-foreground flex-shrink-0')}>
+            <div className={cn('text-accent-foreground select-none flex-shrink-0')}>
               {' '}
               {t('showcase.sections.collections')}
             </div>

--- a/src/renderer/src/components/Showcase/Collections.tsx
+++ b/src/renderer/src/components/Showcase/Collections.tsx
@@ -24,7 +24,7 @@ export function Collections(): JSX.Element {
   return (
     <div className={cn('w-full flex flex-col gap-1')}>
       <div className={cn('flex flex-row items-center gap-5 justify-center pl-5')}>
-        <div className={cn('text-accent-foreground flex-shrink-0')}>
+        <div className={cn('text-accent-foreground select-none flex-shrink-0')}>
           {t('showcase.sections.collections')}
         </div>
 

--- a/src/renderer/src/components/Showcase/RecentGames.tsx
+++ b/src/renderer/src/components/Showcase/RecentGames.tsx
@@ -1,12 +1,12 @@
-import { cn } from '~/utils'
 import { Button } from '@ui/button'
+import { throttle } from 'lodash'
+import { useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useConfigState } from '~/hooks'
 import { sortGames } from '~/stores/game'
-import { GamePoster } from './posters/GamePoster'
+import { cn } from '~/utils'
 import { BigGamePoster } from './posters/BigGamePoster'
-import { useRef } from 'react'
-import { throttle } from 'lodash'
-import { useTranslation } from 'react-i18next'
+import { GamePoster } from './posters/GamePoster'
 
 export function RecentGames(): JSX.Element {
   const games = sortGames('record.lastRunDate', 'desc').slice(0, 15)
@@ -26,7 +26,7 @@ export function RecentGames(): JSX.Element {
   return (
     <div className={cn('w-full flex flex-col gap-1')}>
       <div className={cn('flex flex-row items-center gap-5 justify-center pl-5')}>
-        <div className={cn('text-accent-foreground flex-shrink-0')}>
+        <div className={cn('text-accent-foreground select-none flex-shrink-0')}>
           {t('showcase.sections.recentGames')}
         </div>
 

--- a/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
@@ -1,6 +1,7 @@
-import { ContextMenu, ContextMenuTrigger } from '@ui/context-menu'
 import { Button } from '@ui/button'
+import { ContextMenu, ContextMenuTrigger } from '@ui/context-menu'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { HoverCardAnimation } from '~/components/animations/HoverCard'
 import { GameNavCM } from '~/components/contextMenu/GameNavCM'
@@ -9,10 +10,9 @@ import { NameEditorDialog } from '~/components/Game/Config/ManageMenu/NameEditor
 import { PlayTimeEditorDialog } from '~/components/Game/Config/ManageMenu/PlayTimeEditorDialog'
 import { GameImage } from '~/components/ui/game-image'
 import { useGameState } from '~/hooks'
+import { useRunningGames } from '~/pages/Library/store'
 import { useGameRegistry } from '~/stores/game'
 import { cn, navigateToGame, startGame, stopGame } from '~/utils'
-import { useRunningGames } from '~/pages/Library/store'
-import { useTranslation } from 'react-i18next'
 
 export function BigGamePoster({
   gameId,
@@ -57,7 +57,7 @@ export function BigGamePoster({
                   gameId={gameId}
                   type="background"
                   className={cn(
-                    'h-[222px] aspect-[3/2] cursor-pointer object-contain rounded-lg bg-accent/30',
+                    'h-[222px] aspect-[3/2] cursor-pointer select-none object-contain rounded-lg bg-accent/30',
                     className
                   )}
                   fallback={
@@ -111,7 +111,7 @@ export function BigGamePoster({
                 </div>
 
                 {/* Game info */}
-                <div className="flex flex-col gap-2 mt-auto text-xs font-semibold">
+                <div className="flex flex-col gap-2 mt-auto text-xs font-semibold select-none">
                   {/* Play time */}
                   <div className="flex flex-row items-center justify-start gap-2">
                     <span className="icon-[mdi--access-time] w-4 h-4"></span>
@@ -137,7 +137,7 @@ export function BigGamePoster({
               </div>
             </div>
 
-            <div className="text-[13px] cursor-pointer text-foreground hover:underline decoration-foreground truncate w-[333px] text-center">
+            <div className="text-[13px] cursor-pointer select-none text-foreground hover:underline decoration-foreground truncate w-[333px] text-center">
               {gameData?.name}
             </div>
           </div>

--- a/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
@@ -32,7 +32,7 @@ function Preview({
   return (
     <div
       className={cn(
-        'group relative overflow-hidden w-[150px] h-[150px] rounded-lg',
+        'group relative overflow-hidden w-[155px] h-[155px] rounded-lg',
         'transition-all duration-300 ease-in-out',
         'border-4 border-dashed border-primary',
         !transparentBackground && ' bg-background'

--- a/src/renderer/src/components/Showcase/posters/GamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/GamePoster.tsx
@@ -1,18 +1,18 @@
+import { Button } from '@ui/button'
 import { ContextMenu, ContextMenuTrigger } from '@ui/context-menu'
 import { GameImage } from '@ui/game-image'
-import { Button } from '@ui/button'
 import { useEffect, useRef, useState } from 'react'
-import { HoverCardAnimation } from '~/components/animations/HoverCard'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
+import { HoverCardAnimation } from '~/components/animations/HoverCard'
 import { GameNavCM } from '~/components/contextMenu/GameNavCM'
 import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
 import { NameEditorDialog } from '~/components/Game/Config/ManageMenu/NameEditorDialog'
 import { PlayTimeEditorDialog } from '~/components/Game/Config/ManageMenu/PlayTimeEditorDialog'
 import { useDragContext } from '~/components/Showcase/CollectionGames'
 import { useGameState } from '~/hooks'
-import { useGameCollectionStore, useGameRegistry } from '~/stores/game'
 import { useRunningGames } from '~/pages/Library/store'
+import { useGameCollectionStore, useGameRegistry } from '~/stores/game'
 import { cn, navigateToGame, startGame, stopGame } from '~/utils'
 import {
   attachClosestEdge,
@@ -180,7 +180,7 @@ export function GamePoster({
                       type="cover"
                       alt={gameId}
                       className={cn(
-                        'w-[148px] aspect-[2/3] cursor-pointer object-cover rounded-lg',
+                        'w-[148px] aspect-[2/3] cursor-pointer select-none object-cover rounded-lg',
                         className
                       )}
                       fallback={
@@ -191,7 +191,7 @@ export function GamePoster({
                           )}
                           onClick={() => navigateToGame(navigate, gameId, groupId || 'all')}
                         >
-                          <div className="p-1 font-bold truncate">{gameName}</div>
+                          <div className="p-1 font-bold truncate select-none">{gameName}</div>
                         </div>
                       }
                     />
@@ -236,7 +236,7 @@ export function GamePoster({
                     </div>
 
                     {/* Game info */}
-                    <div className="flex flex-col gap-2 mt-auto text-xs font-semibold">
+                    <div className="flex flex-col gap-2 mt-auto text-xs font-semibold select-none">
                       {/* Play time */}
                       <div className="flex flex-row items-center justify-start gap-2">
                         <span className="icon-[mdi--access-time] w-4 h-4"></span>
@@ -262,7 +262,7 @@ export function GamePoster({
                   </div>
                 </div>
 
-                <div className="text-[13px] text-foreground truncate cursor-pointer hover:underline w-[148px] text-center decoration-foreground">
+                <div className="text-[13px] text-foreground truncate cursor-pointer select-none hover:underline w-[148px] text-center decoration-foreground">
                   {gameData?.name}
                 </div>
               </div>


### PR DESCRIPTION
### 修复拖拽相关的样式问题：
- 收藏夹图标的拖拽预览尺寸
- 拖拽提示器的位置计算

### 阻止了若干文本选择：
- 游戏详情页的游戏名称
- 游戏海报
- 主页边边角角的文本
- 收藏夹页面边边角角的文本
- 收藏夹游戏页边边角角的文本