### PR TITLE
fix: Prevent displaying recent games when no run records exist

### DIFF
--- a/src/renderer/locales/en/game.json
+++ b/src/renderer/locales/en/game.json
@@ -21,7 +21,8 @@
     },
     "recent": {
       "title": "Recent Games",
-      "hide": "Hide"
+      "hide": "Hide",
+      "empty": "No recent games"
     },
     "filter": {
       "results": "Filter Results",

--- a/src/renderer/locales/zh-CN/game.json
+++ b/src/renderer/locales/zh-CN/game.json
@@ -21,7 +21,8 @@
     },
     "recent": {
       "title": "最近游戏",
-      "hide": "隐藏"
+      "hide": "隐藏",
+      "empty": "暂无最近游戏"
     },
     "filter": {
       "results": "筛选结果",

--- a/src/renderer/locales/zh-TW/game.json
+++ b/src/renderer/locales/zh-TW/game.json
@@ -21,7 +21,8 @@
     },
     "recent": {
       "title": "最近遊戲",
-      "hide": "隱藏"
+      "hide": "隱藏",
+      "empty": "暫無最近遊戲"
     },
     "filter": {
       "results": "篩選結果",

--- a/src/renderer/src/components/Librarybar/GameList/RecentGames.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/RecentGames.tsx
@@ -1,21 +1,26 @@
-import { cn } from '~/utils'
 import { AccordionContent, AccordionItem, AccordionTrigger } from '@ui/accordion'
 import {
-  ContextMenuContent,
-  ContextMenuTrigger,
   ContextMenu,
-  ContextMenuItem
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
 } from '@ui/context-menu'
-import { useConfigState } from '~/hooks'
-import { sortGames } from '~/stores/game'
-import { GameNav } from '../GameNav'
 import { useTranslation } from 'react-i18next'
+import { useConfigState } from '~/hooks'
+import { getGameStore, sortGames } from '~/stores/game'
+import { cn } from '~/utils'
+import { GameNav } from '../GameNav'
 
 export function RecentGames(): JSX.Element {
   const [showRecentGamesInGameList, setShowRecentGamesInGameList] = useConfigState(
     'game.gameList.showRecentGames'
   )
-  const games = sortGames('record.lastRunDate', 'desc').slice(0, 5)
+  const games = sortGames('record.lastRunDate', 'desc')
+    .slice(0, 5)
+    .filter((id) => {
+      const date = getGameStore(id).getState().getValue('record.lastRunDate')
+      return date && date !== ''
+    })
   const { t } = useTranslation('game')
   return (
     <>
@@ -36,6 +41,11 @@ export function RecentGames(): JSX.Element {
             </ContextMenuContent>
           </ContextMenu>
           <AccordionContent className={cn('rounded-none pt-1 flex flex-col gap-1')}>
+            {games.length === 0 && (
+              <div className="flex items-center justify-center text-muted-foreground text-xs mt-3">
+                {t('list.recent.empty')}
+              </div>
+            )}
             {games.map((gameId) => (
               <GameNav key={gameId} gameId={gameId} groupId="recentGames" />
             ))}

--- a/src/renderer/src/components/Showcase/RecentGames.tsx
+++ b/src/renderer/src/components/Showcase/RecentGames.tsx
@@ -3,13 +3,18 @@ import { throttle } from 'lodash'
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useConfigState } from '~/hooks'
-import { sortGames } from '~/stores/game'
+import { getGameStore, sortGames } from '~/stores/game'
 import { cn } from '~/utils'
 import { BigGamePoster } from './posters/BigGamePoster'
 import { GamePoster } from './posters/GamePoster'
 
 export function RecentGames(): JSX.Element {
-  const games = sortGames('record.lastRunDate', 'desc').slice(0, 15)
+  const games = sortGames('record.lastRunDate', 'desc')
+    .slice(0, 15)
+    .filter((id) => {
+      const date = getGameStore(id).getState().getValue('record.lastRunDate')
+      return date && date !== ''
+    })
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const [showRecentGamesInGameList] = useConfigState('game.gameList.showRecentGames')
 
@@ -64,6 +69,9 @@ export function RecentGames(): JSX.Element {
         )}
       >
         {/* The wrapper ensures that each Poster maintains a fixed width */}
+        {games.length === 0 && (
+          <div className="text-muted-foreground text-sm">{t('list.recent.empty')}</div>
+        )}
         {games.map((game, index) =>
           index === 0 ? (
             <div


### PR DESCRIPTION
为`最近游戏`的显示添加了过滤，避免在存在游玩记录的游戏数量不足的情况下，错误地将其他游戏显示为`最近游戏`。