### PR TITLE
feat: add quick access buttons for editing play time, play status and game score on game details page

### DIFF
--- a/src/renderer/src/components/Game/Config/ManageMenu/RatingEditorDialog.tsx
+++ b/src/renderer/src/components/Game/Config/ManageMenu/RatingEditorDialog.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { Button } from '~/components/ui/button'
+import { Dialog, DialogContent } from '~/components/ui/dialog'
+import { Input } from '~/components/ui/input'
+import { useGameState } from '~/hooks'
+import { cn } from '~/utils'
+
+export function RatingEditorDialog({
+  gameId,
+  setIsOpen
+}: {
+  gameId: string
+  setIsOpen: (value: boolean) => void
+}): React.JSX.Element {
+  const { t } = useTranslation('game')
+  const [score, setScore] = useGameState(gameId, 'record.score')
+  const [preScore, setPreScore] = useState(score === -1 ? '' : score.toString())
+  const resetPreScore = (): void => setPreScore(score === -1 ? '' : score.toString())
+
+  // Score submission handler function
+  function confirmScore(): void {
+    if (preScore === '') {
+      setScore(-1)
+      setIsOpen(false)
+      toast.success(t('detail.header.rating.cleared'))
+      return
+    }
+
+    const scoreNum = parseFloat(preScore)
+
+    if (isNaN(scoreNum)) {
+      toast.error(t('detail.header.rating.errors.invalidNumber'))
+      resetPreScore()
+      return
+    }
+
+    if (scoreNum < 0) {
+      toast.error(t('detail.header.rating.errors.negative'))
+      resetPreScore()
+      return
+    }
+
+    if (scoreNum > 10) {
+      toast.error(t('detail.header.rating.errors.tooHigh'))
+      resetPreScore()
+      return
+    }
+
+    const formattedScore = scoreNum.toFixed(1)
+
+    if (preScore !== formattedScore && !Number.isInteger(scoreNum)) {
+      toast.warning(t('detail.header.rating.warning'))
+    }
+
+    setScore(Number(formattedScore))
+    setPreScore(Number(formattedScore).toString())
+    setIsOpen(false)
+    toast.success(t('detail.header.rating.success'))
+  }
+
+  return (
+    <Dialog open={true} onOpenChange={setIsOpen}>
+      <DialogContent showCloseButton={false} className="w-[500px]">
+        <div className={cn('flex flex-row gap-3 items-center justify-center')}>
+          <div className={cn('whitespace-nowrap')}>{t('detail.header.rating.title')}</div>
+          <Input
+            value={preScore}
+            onChange={(e) => setPreScore(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') confirmScore()
+            }}
+          />
+          <Button onClick={confirmScore}>{t('utils:common.confirm')}</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/Game/Config/ManageMenu/main.tsx
+++ b/src/renderer/src/components/Game/Config/ManageMenu/main.tsx
@@ -1,3 +1,7 @@
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { ipcManager } from '~/app/ipc'
+import { useLibrarybarStore } from '~/components/Librarybar/store'
 import {
   DropdownMenuGroup,
   DropdownMenuItem,
@@ -7,28 +11,17 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger
 } from '~/components/ui/dropdown-menu'
-import { useTranslation } from 'react-i18next'
-import { toast } from 'sonner'
-import { useGameLocalState, useGameState, useConfigState } from '~/hooks'
+import { useConfigState, useGameLocalState, useGameState } from '~/hooks'
 import { useGameAdderStore } from '~/pages/GameAdder/store'
 import { useGameDetailStore } from '../../store'
-import { useLibrarybarStore } from '~/components/Librarybar/store'
 import { DeleteGameAlert } from './DeleteGameAlert'
-import { ipcManager } from '~/app/ipc'
-import { useState } from 'react'
-import { Dialog, DialogContent } from '~/components/ui/dialog'
-import { Input } from '~/components/ui/input'
-import { Button } from '~/components/ui/button'
-import { cn } from '~/utils'
 
 export function ManageMenu({
   gameId,
-  openNameEditorDialog,
-  openPlayingTimeEditorDialog
+  openNameEditorDialog
 }: {
   gameId: string
   openNameEditorDialog: () => void
-  openPlayingTimeEditorDialog: () => void
 }): React.JSX.Element {
   const { t } = useTranslation('game')
   const [gamePath] = useGameLocalState(gameId, 'path.gamePath')
@@ -36,64 +29,24 @@ export function ManageMenu({
   const [gameName] = useGameState(gameId, 'metadata.name')
   const [nsfw, setNsfw] = useGameState(gameId, 'apperance.nsfw')
   const [playStatus, setPlayStatus] = useGameState(gameId, 'record.playStatus')
-  const [score, setScore] = useGameState(gameId, 'record.score')
-  const [preScore, setPreScore] = useState(score === -1 ? '' : score.toString())
   const [selectedGroup] = useConfigState('game.gameList.selectedGroup')
-  const [isScoreDialogOpen, setIsScoreDialogOpen] = useState(false)
   const { refreshGameList } = useLibrarybarStore.getState()
   const setIsEditingLogo = useGameDetailStore((state) => state.setIsEditingLogo)
+  const setIsPlayTimeEditorDialogOpen = useGameDetailStore(
+    (state) => state.setIsPlayTimeEditorDialogOpen
+  )
+  const setIsRatingEditorDialogOpen = useGameDetailStore(
+    (state) => state.setIsRatingEditorDialogOpen
+  )
   const setIsOpen = useGameAdderStore((state) => state.setIsOpen)
   const setName = useGameAdderStore((state) => state.setName)
   const setDbId = useGameAdderStore((state) => state.setDbId)
-
-  const resetPreScore = (): void => setPreScore(score === -1 ? '' : score.toString())
 
   const changePlayStatus = (value: typeof playStatus): void => {
     setPlayStatus(value)
     if (selectedGroup === 'record.playStatus') {
       refreshGameList()
     }
-  }
-
-  // Score submission handler function
-  function confirmScore(): void {
-    if (preScore === '') {
-      setScore(-1)
-      setIsScoreDialogOpen(false)
-      toast.success(t('detail.header.rating.cleared'))
-      return
-    }
-
-    const scoreNum = parseFloat(preScore)
-
-    if (isNaN(scoreNum)) {
-      toast.error(t('detail.header.rating.errors.invalidNumber'))
-      resetPreScore()
-      return
-    }
-
-    if (scoreNum < 0) {
-      toast.error(t('detail.header.rating.errors.negative'))
-      resetPreScore()
-      return
-    }
-
-    if (scoreNum > 10) {
-      toast.error(t('detail.header.rating.errors.tooHigh'))
-      resetPreScore()
-      return
-    }
-
-    const formattedScore = scoreNum.toFixed(1)
-
-    if (preScore !== formattedScore && !Number.isInteger(scoreNum)) {
-      toast.warning(t('detail.header.rating.warning'))
-    }
-
-    setScore(Number(formattedScore))
-    setPreScore(Number(formattedScore).toString())
-    setIsScoreDialogOpen(false)
-    toast.success(t('detail.header.rating.success'))
   }
 
   return (
@@ -114,7 +67,7 @@ export function ManageMenu({
                 {t('detail.manage.editLogo')}
               </DropdownMenuItem>
 
-              <DropdownMenuItem onClick={openPlayingTimeEditorDialog}>
+              <DropdownMenuItem onClick={() => setIsPlayTimeEditorDialogOpen(true)}>
                 {t('detail.manage.editPlayTime')}
               </DropdownMenuItem>
 
@@ -162,13 +115,7 @@ export function ManageMenu({
               </DropdownMenuSub>
 
               {/* Rating menu item */}
-              <DropdownMenuItem
-                onSelect={(e) => {
-                  e.preventDefault()
-                  resetPreScore()
-                  setIsScoreDialogOpen(true)
-                }}
-              >
+              <DropdownMenuItem onSelect={() => setIsRatingEditorDialogOpen(true)}>
                 {t('detail.header.rating.tooltip')}
               </DropdownMenuItem>
 
@@ -228,23 +175,6 @@ export function ManageMenu({
           </DropdownMenuPortal>
         </DropdownMenuSub>
       </DropdownMenuGroup>
-
-      {/* Rating dialog */}
-      <Dialog open={isScoreDialogOpen} onOpenChange={setIsScoreDialogOpen}>
-        <DialogContent showCloseButton={false} className="w-[500px]">
-          <div className={cn('flex flex-row gap-3 items-center justify-center')}>
-            <div className={cn('whitespace-nowrap')}>{t('detail.header.rating.title')}</div>
-            <Input
-              value={preScore}
-              onChange={(e) => setPreScore(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') confirmScore()
-              }}
-            />
-            <Button onClick={confirmScore}>{t('utils:common.confirm')}</Button>
-          </div>
-        </DialogContent>
-      </Dialog>
     </>
   )
 }

--- a/src/renderer/src/components/Game/Config/main.tsx
+++ b/src/renderer/src/components/Game/Config/main.tsx
@@ -1,3 +1,6 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
 import { Button } from '~/components/ui/button'
 import {
   DropdownMenu,
@@ -6,21 +9,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from '~/components/ui/dropdown-menu'
-import React from 'react'
-import { AddCollectionDialog } from '~/components/dialog/AddCollectionDialog'
 import { cn } from '~/utils'
 import { CollectionMenu } from './CollectionMenu'
 import { ManageMenu } from './ManageMenu'
 import { NameEditorDialog } from './ManageMenu/NameEditorDialog'
-import { PlayTimeEditorDialog } from './ManageMenu/PlayTimeEditorDialog'
 import { GamePropertiesDialog } from './Properties'
-import { useTranslation } from 'react-i18next'
 
 export function Config({ gameId }: { gameId: string }): React.JSX.Element {
   const { t } = useTranslation('game')
 
   const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = React.useState(false)
-  const [isPlayTimeEditorDialogOpen, setIsPlayTimeEditorDialogOpen] = React.useState(false)
   const [isNameEditorDialogOpen, setIsNameEditorDialogOpen] = React.useState(false)
   const [isPropertiesDialogOpen, setIsPropertiesDialogOpen] = React.useState(false)
 
@@ -41,7 +39,6 @@ export function Config({ gameId }: { gameId: string }): React.JSX.Element {
           <ManageMenu
             gameId={gameId}
             openNameEditorDialog={() => setIsNameEditorDialogOpen(true)}
-            openPlayingTimeEditorDialog={() => setIsPlayTimeEditorDialogOpen(true)}
           />
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => setIsPropertiesDialogOpen(true)}>
@@ -54,9 +51,6 @@ export function Config({ gameId }: { gameId: string }): React.JSX.Element {
       )}
       {isNameEditorDialogOpen && (
         <NameEditorDialog gameId={gameId} setIsOpen={setIsNameEditorDialogOpen} />
-      )}
-      {isPlayTimeEditorDialogOpen && (
-        <PlayTimeEditorDialog gameId={gameId} setIsOpen={setIsPlayTimeEditorDialogOpen} />
       )}
       {isPropertiesDialogOpen && (
         <GamePropertiesDialog

--- a/src/renderer/src/components/Game/Header.tsx
+++ b/src/renderer/src/components/Game/Header.tsx
@@ -1,11 +1,15 @@
-import { GameImage } from '../ui/game-image'
+import React from 'react'
 import { useConfigState, useGameState } from '~/hooks'
 import { useRunningGames } from '~/pages/Library/store'
 import { cn, copyWithToast } from '~/utils'
+import { GameImage } from '../ui/game-image'
 import { Config } from './Config'
+import { PlayTimeEditorDialog } from './Config/ManageMenu/PlayTimeEditorDialog'
+import { RatingEditorDialog } from './Config/ManageMenu/RatingEditorDialog'
 import { Record } from './Overview/Record'
 import { StartGame } from './StartGame'
 import { StopGame } from './StopGame'
+import { useGameDetailStore } from './store'
 
 export function Header({
   gameId,
@@ -21,65 +25,85 @@ export function Header({
   const [enableNSFWBlur] = useConfigState('appearances.enableNSFWBlur')
   const [nsfw] = useGameState(gameId, 'apperance.nsfw')
 
+  const isPlayTimeEditorDialogOpen = useGameDetailStore((state) => state.isPlayTimeEditorDialogOpen)
+  const setIsPlayTimeEditorDialogOpen = useGameDetailStore(
+    (state) => state.setIsPlayTimeEditorDialogOpen
+  )
+  const isRatingEditorDialogOpen = useGameDetailStore((state) => state.isRatingEditorDialogOpen)
+  const setIsRatingEditorDialogOpen = useGameDetailStore(
+    (state) => state.setIsRatingEditorDialogOpen
+  )
+
   return (
-    <div className={cn('flex-col flex gap-5 px-7 py-5 pl-6 pt-6 relative', className)}>
-      {/* Game name section */}
-      <div className="flex flex-row justify-between items-end">
-        <div
-          className={cn('flex flex-col gap-3 grow overflow-hidden items-start justify-start pl-1')}
-        >
+    <>
+      <div className={cn('flex-col flex gap-5 px-7 py-5 pl-6 pt-6 relative', className)}>
+        {/* Game name section */}
+        <div className="flex flex-row justify-between items-end">
           <div
             className={cn(
-              'font-bold text-2xl text-accent-foreground cursor-pointer select-none text-shadow-lg'
+              'flex flex-col gap-3 grow overflow-hidden items-start justify-start pl-1'
             )}
-            onClick={() => copyWithToast(name)}
           >
-            {name}
-          </div>
-          {showOriginalNameInGameHeader && originalName && (
             <div
-              className={cn('font-bold text-accent-foreground cursor-pointer select-none')}
-              onClick={() => copyWithToast(originalName)}
-            >
-              {originalName}
-            </div>
-          )}
-          <div
-            className={cn(
-              'flex flex-row justify-between items-end duration-300 select-none mt-2 pb-1',
-              '3xl:gap-5'
-            )}
-          >
-            {/* Game records and action buttons */}
-
-            <div className={cn('flex flex-row gap-3 items-end z-20', '3xl:gap-5')}>
-              {/* Start/Stop game button */}
-              {runningGames.includes(gameId) ? (
-                <StopGame gameId={gameId} className={cn('w-[170px] h-[40px]')} />
-              ) : (
-                <StartGame gameId={gameId} className={cn('w-[170px] h-[40px]')} />
+              className={cn(
+                'font-bold text-2xl text-accent-foreground cursor-pointer select-none text-shadow-lg'
               )}
+              onClick={() => copyWithToast(name)}
+            >
+              {name}
+            </div>
+            {showOriginalNameInGameHeader && originalName && (
+              <div
+                className={cn('font-bold text-accent-foreground cursor-pointer select-none')}
+                onClick={() => copyWithToast(originalName)}
+              >
+                {originalName}
+              </div>
+            )}
+            <div
+              className={cn(
+                'flex flex-row justify-between items-end duration-300 select-none mt-2 pb-1',
+                '3xl:gap-5'
+              )}
+            >
+              {/* Game records and action buttons */}
 
-              {/* Configuration button */}
-              <Config gameId={gameId} />
+              <div className={cn('flex flex-row gap-3 items-end z-20', '3xl:gap-5')}>
+                {/* Start/Stop game button */}
+                {runningGames.includes(gameId) ? (
+                  <StopGame gameId={gameId} className={cn('w-[170px] h-[40px]')} />
+                ) : (
+                  <StartGame gameId={gameId} className={cn('w-[170px] h-[40px]')} />
+                )}
+
+                {/* Configuration button */}
+                <Config gameId={gameId} />
+              </div>
             </div>
           </div>
+          <div className="relative lg:mr-3 pb-1 shrink-0">
+            <GameImage
+              gameId={gameId}
+              key={`${gameId}-poster`}
+              type="cover"
+              blur={enableNSFWBlur && nsfw}
+              className={cn('w-auto h-[170px] object-cover rounded-lg shadow-md')}
+              fallback={<div className="h-[170px]" />}
+            />
+            {/* <div className="absolute inset-0 rounded-lg bg-background/15" /> */}
+          </div>
         </div>
-        <div className="relative lg:mr-3 pb-1 shrink-0">
-          <GameImage
-            gameId={gameId}
-            key={`${gameId}-poster`}
-            type="cover"
-            blur={enableNSFWBlur && nsfw}
-            className={cn('w-auto h-[170px] object-cover rounded-lg shadow-md')}
-            fallback={<div className="h-[170px]" />}
-          />
-          {/* <div className="absolute inset-0 rounded-lg bg-background/15" /> */}
+        <div className="pt-6">
+          <Record gameId={gameId} />
         </div>
       </div>
-      <div className="pt-6">
-        <Record gameId={gameId} />
-      </div>
-    </div>
+
+      {isPlayTimeEditorDialogOpen && (
+        <PlayTimeEditorDialog gameId={gameId} setIsOpen={setIsPlayTimeEditorDialogOpen} />
+      )}
+      {isRatingEditorDialogOpen && (
+        <RatingEditorDialog gameId={gameId} setIsOpen={setIsRatingEditorDialogOpen} />
+      )}
+    </>
   )
 }

--- a/src/renderer/src/components/Game/Overview/Record/RecordCard.tsx
+++ b/src/renderer/src/components/Game/Overview/Record/RecordCard.tsx
@@ -1,19 +1,38 @@
+import React from 'react'
+import { Button } from '~/components/ui/button'
+import { PopoverTrigger } from '~/components/ui/popover'
 import { cn } from '~/utils'
 
 export function RecordCard({
   title,
   content,
   icon,
+  onClick,
+  asPopoverTrigger,
   className = ''
 }: {
   title: string
   content: string
   icon?: string
+  onClick?: () => void
+  asPopoverTrigger?: boolean
   className?: string
 }): React.JSX.Element {
+  const ButtonWrapper = ({ children }: { children: React.ReactNode }): React.JSX.Element =>
+    asPopoverTrigger ? <PopoverTrigger asChild>{children}</PopoverTrigger> : <>{children}</>
+  const isInteractive = onClick || asPopoverTrigger
   return (
     <div className={cn('flex flex-row justify-center items-center', className)}>
-      <span className={cn(icon, 'w-[30px] h-[30px] mr-3')}></span>
+      {isInteractive ? (
+        <ButtonWrapper>
+          <Button variant={'bare'} size={'icon'} className={cn('group  mr-3')} onClick={onClick}>
+            <span className={cn(icon, 'w-[30px] h-[30px] group-hover:text-primary')}></span>
+          </Button>
+        </ButtonWrapper>
+      ) : (
+        <span className={cn(icon, 'w-[30px] h-[30px] mr-3')}></span>
+      )}
+
       <div
         className={cn(
           'flex flex-col gap-1 text-xs text-accent-foreground/90 justify-center items-start'

--- a/src/renderer/src/components/Game/Overview/Record/main.tsx
+++ b/src/renderer/src/components/Game/Overview/Record/main.tsx
@@ -1,15 +1,36 @@
+import { Check } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { cn } from '~/utils'
-import { RecordCard } from './RecordCard'
+import { useLibrarybarStore } from '~/components/Librarybar/store'
+import { Popover, PopoverContent } from '~/components/ui/popover'
 import { useGameState } from '~/hooks'
+import { cn } from '~/utils'
+import { useGameDetailStore } from '../../store'
+import { RecordCard } from './RecordCard'
 
 export function Record({ gameId }: { gameId: string }): React.JSX.Element {
   const { t } = useTranslation('game')
   const [lastRunDate] = useGameState(gameId, 'record.lastRunDate')
-  const [playStatus] = useGameState(gameId, 'record.playStatus')
   const [score] = useGameState(gameId, 'record.score')
   const [playingTime] = useGameState(gameId, 'record.playTime')
-
+  const [playStatus, setPlayStatus] = useGameState(gameId, 'record.playStatus')
+  const { refreshGameList } = useLibrarybarStore.getState()
+  const setIsPlayTimeEditorDialogOpen = useGameDetailStore(
+    (state) => state.setIsPlayTimeEditorDialogOpen
+  )
+  const setIsRatingEditorDialogOpen = useGameDetailStore(
+    (state) => state.setIsRatingEditorDialogOpen
+  )
+  const playStatusOptions: (typeof playStatus)[] = [
+    'unplayed',
+    'playing',
+    'finished',
+    'multiple',
+    'shelved'
+  ]
+  const changePlayStatus = (status: typeof playStatus): void => {
+    setPlayStatus(status)
+    refreshGameList()
+  }
   return (
     <div className={cn('flex flex-row items-center gap-12 ml-1')}>
       <RecordCard
@@ -21,6 +42,7 @@ export function Record({ gameId }: { gameId: string }): React.JSX.Element {
             : t('detail.overview.information.empty')
         }
         icon="icon-[mdi--timer-outline] w-[16px] h-[16px]"
+        onClick={() => setIsPlayTimeEditorDialogOpen(true)}
       />
       <RecordCard
         className={cn('')}
@@ -32,17 +54,38 @@ export function Record({ gameId }: { gameId: string }): React.JSX.Element {
         }
         icon="icon-[mdi--calendar-blank-multiple] w-[16px] h-[16px]"
       />
-      <RecordCard
-        className={cn('')}
-        title={t('detail.overview.record.playStatus')}
-        content={t(`utils:game.playStatus.${playStatus}`)}
-        icon="icon-[mdi--bookmark-outline] w-[16px] h-[16px]"
-      />
+      <Popover>
+        <RecordCard
+          asPopoverTrigger
+          className={cn('')}
+          title={t('detail.overview.record.playStatus')}
+          content={t(`utils:game.playStatus.${playStatus}`)}
+          icon="icon-[mdi--bookmark-outline] w-[16px] h-[16px]"
+        />
+        <PopoverContent className="max-w-[150px] p-1">
+          <div className="flex flex-col">
+            {playStatusOptions.map((opt) => (
+              <div
+                key={opt}
+                onClick={() => changePlayStatus(opt)}
+                className={cn(
+                  'flex flex-row items-center justify-between px-2 py-2 text-sm cursor-pointer',
+                  'hover:bg-background'
+                )}
+              >
+                {t('utils:game.playStatus.' + opt)}
+                {playStatus === opt && <Check className="w-4 h-4" />}
+              </div>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
       <RecordCard
         className={cn('')}
         title={t('detail.overview.record.rating')}
         content={score === -1 ? t('detail.overview.information.empty') : score.toFixed(1)}
         icon="icon-[mdi--starburst-outline] w-[16px] h-[16px]"
+        onClick={() => setIsRatingEditorDialogOpen(true)}
       />
     </div>
   )

--- a/src/renderer/src/components/Game/store.ts
+++ b/src/renderer/src/components/Game/store.ts
@@ -3,9 +3,21 @@ import { create } from 'zustand'
 export interface GameDetailStore {
   isEditingLogo: boolean
   setIsEditingLogo: (isEditing: boolean) => void
+
+  isPlayTimeEditorDialogOpen: boolean
+  setIsPlayTimeEditorDialogOpen: (open: boolean) => void
+
+  isRatingEditorDialogOpen: boolean
+  setIsRatingEditorDialogOpen: (open: boolean) => void
 }
 
 export const useGameDetailStore = create<GameDetailStore>((set) => ({
   isEditingLogo: false,
-  setIsEditingLogo: (isEditing): void => set({ isEditingLogo: isEditing })
+  setIsEditingLogo: (isEditing): void => set({ isEditingLogo: isEditing }),
+
+  isPlayTimeEditorDialogOpen: false,
+  setIsPlayTimeEditorDialogOpen: (open): void => set({ isPlayTimeEditorDialogOpen: open }),
+
+  isRatingEditorDialogOpen: false,
+  setIsRatingEditorDialogOpen: (open) => set({ isRatingEditorDialogOpen: open })
 }))

--- a/src/renderer/src/components/ui/button.tsx
+++ b/src/renderer/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
 
 import { cn } from '~/utils'
 
@@ -18,7 +18,8 @@ const buttonVariants = cva(
           'bg-input/30 shadow-sm text-background-foreground hover:text-accent-foreground hover:bg-input/50',
         secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
-        link: 'text-primary underline-offset-4 hover:underline'
+        link: 'text-primary underline-offset-4 hover:underline',
+        bare: 'bg-transparent shadow-none hover:bg-transparent'
       },
       size: {
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',


### PR DESCRIPTION
把详情页Header中的三个展示游玩时间、游玩状态、游戏评分的图标改成了按钮，点击可以弹出对应的修改对话框。同时仍然保留了设置下拉框里面的修改入口，为了支持这种多个触发入口的情况，把这两个对话框的状态放到zustand中管理了。

> 这种对话框会阻断其他操作，所以不会出现在打开对话框时切换其他游戏的情况。但是测的时候导致发现编辑logo的那个状态在切换游戏后仍然会保留，不知道是否符合预期。