### PR TITLE
feat: add tiered NSFW content filtering

### DIFF
--- a/src/renderer/locales/en/sidebar.json
+++ b/src/renderer/locales/en/sidebar.json
@@ -9,8 +9,11 @@
   },
   "actions": {
     "viewLogs": "View Logs",
-    "enableNSFWBlur": "Hide NSFW Content",
-    "disableNSFWBlur": "Show NSFW Content",
+    "nsfwLevel": {
+      "off": "NSFW: Show all",
+      "blurImage": "NSFW: Hide images",
+      "blurImageAndTitle": "NSFW: Hide images and titles"
+    },
     "darkMode": "Dark Mode",
     "lightMode": "Light Mode",
     "cloudSyncDisabled": "Cloud Sync Disabled",

--- a/src/renderer/locales/it/sidebar.json
+++ b/src/renderer/locales/it/sidebar.json
@@ -7,8 +7,6 @@
     "transformer": ""
   },
   "actions": {
-    "enableNSFWBlur": "",
-    "disableNSFWBlur": "",
     "darkMode": "",
     "lightMode": "",
     "cloudSyncDisabled": "",

--- a/src/renderer/locales/ja/sidebar.json
+++ b/src/renderer/locales/ja/sidebar.json
@@ -4,17 +4,21 @@
     "library": "ゲームライブラリ",
     "records": "記録",
     "scanner": "スキャナー",
-    "transformer": "変換器"
+    "transformer": "変換器",
+    "plugin": "プラグイン"
   },
   "actions": {
     "viewLogs": "ログを表示",
+    "nsfwLevel": {
+      "off": "NSFW：非表示なし",
+      "blurImage": "NSFW：画像を非表示",
+      "blurImageAndTitle": "NSFW：画像とタイトルを非表示"
+    },
     "darkMode": "ダークモード",
     "lightMode": "ライトモード",
     "cloudSyncDisabled": "クラウド同期が無効",
     "addGame": "ゲームを追加",
-    "settings": "設定",
-    "enableNSFWBlur": "NSFW コンテンツを非表示にする",
-    "disableNSFWBlur": "NSFW コンテンツを表示する"
+    "settings": "設定"
   },
   "adder": {
     "addGame": "ゲームを追加",

--- a/src/renderer/locales/ko/sidebar.json
+++ b/src/renderer/locales/ko/sidebar.json
@@ -11,9 +11,7 @@
     "lightMode": "라이트 모드",
     "cloudSyncDisabled": "클라우드 동기화 비활성화됨",
     "addGame": "게임 추가",
-    "settings": "설정",
-    "disableNSFWBlur": "NSFW 콘텐츠 표시",
-    "enableNSFWBlur": "NSFW 콘텐츠 숨김"
+    "settings": "설정"
   },
   "adder": {
     "addGame": "게임 추가",

--- a/src/renderer/locales/zh-CN/sidebar.json
+++ b/src/renderer/locales/zh-CN/sidebar.json
@@ -9,8 +9,11 @@
   },
   "actions": {
     "viewLogs": "查看日志",
-    "enableNSFWBlur": "隐藏 NSFW 内容",
-    "disableNSFWBlur": "显示 NSFW 内容",
+    "nsfwLevel": {
+      "off": "NSFW: 不隐藏",
+      "blurImage": "NSFW: 隐藏图片",
+      "blurImageAndTitle": "NSFW: 隐藏图片与标题"
+    },
     "darkMode": "暗色模式",
     "lightMode": "亮色模式",
     "cloudSyncDisabled": "云同步未开启",

--- a/src/renderer/locales/zh-TW/sidebar.json
+++ b/src/renderer/locales/zh-TW/sidebar.json
@@ -4,17 +4,21 @@
     "library": "遊戲庫",
     "records": "記錄",
     "scanner": "掃描器",
-    "transformer": "轉換器"
+    "transformer": "轉換器",
+    "plugin": "外掛"
   },
   "actions": {
     "viewLogs": "查看日誌",
+    "nsfwLevel": {
+      "off": "NSFW：不隱藏",
+      "blurImage": "NSFW：隱藏圖片",
+      "blurImageAndTitle": "NSFW：隱藏圖片與標題"
+    },
     "darkMode": "暗色模式",
     "lightMode": "亮色模式",
     "cloudSyncDisabled": "雲同步未開啟",
     "addGame": "添加遊戲",
-    "settings": "設定",
-    "enableNSFWBlur": "隱藏 NSFW 內容",
-    "disableNSFWBlur": "顯示 NSFW 內容"
+    "settings": "設定"
   },
   "adder": {
     "addGame": "新增遊戲",

--- a/src/renderer/src/components/Game/Header.tsx
+++ b/src/renderer/src/components/Game/Header.tsx
@@ -1,3 +1,4 @@
+import { NSFWBlurLevel } from '@appTypes/models'
 import React from 'react'
 import { useConfigState, useGameState } from '~/hooks'
 import { useRunningGames } from '~/pages/Library/store'
@@ -22,10 +23,9 @@ export function Header({
   const [name] = useGameState(gameId, 'metadata.name')
   const [originalName] = useGameState(gameId, 'metadata.originalName')
   const [showOriginalNameInGameHeader] = useConfigState('game.gameHeader.showOriginalName')
-  const [enableNSFWBlur] = useConfigState('appearances.enableNSFWBlur')
   const [showCover] = useConfigState('appearances.gameDetail.showCover')
   const [nsfw] = useGameState(gameId, 'apperance.nsfw')
-  const blur = enableNSFWBlur && nsfw
+  const [nsfwBlurLevel] = useConfigState('appearances.nsfwBlurLevel')
 
   const isPlayTimeEditorDialogOpen = useGameDetailStore((state) => state.isPlayTimeEditorDialogOpen)
   const setIsPlayTimeEditorDialogOpen = useGameDetailStore(
@@ -53,7 +53,7 @@ export function Header({
               )}
               onClick={() => copyWithToast(name)}
             >
-              {blur ? (
+              {nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImageAndTitle ? (
                 <>
                   <span className="block group-hover:hidden">{obfuscatedName}</span>
                   <span className="hidden group-hover:block">{name}</span>
@@ -69,7 +69,7 @@ export function Header({
                 )}
                 onClick={() => copyWithToast(originalName)}
               >
-                {blur ? (
+                {nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImageAndTitle ? (
                   <>
                     <span className="block group-hover:hidden">{obfuscatedName}</span>
                     <span className="hidden group-hover:block">{originalName}</span>
@@ -105,7 +105,7 @@ export function Header({
                 gameId={gameId}
                 key={`${gameId}-poster`}
                 type="cover"
-                blur={blur}
+                blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
                 className={cn('w-auto h-[170px] object-cover rounded-lg shadow-md')}
                 fallback={<div className="h-[170px]" />}
               />

--- a/src/renderer/src/components/Game/main.tsx
+++ b/src/renderer/src/components/Game/main.tsx
@@ -1,3 +1,4 @@
+import { NSFWBlurLevel } from '@appTypes/models'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '~/components/ui/button'
@@ -41,8 +42,9 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
   const [logoVisible, setLogoVisible] = useGameState(gameId, 'apperance.logo.visible')
   const [localLogoPosition, setLocalLogoPosition] = useState(initialPosition)
 
-  const [enableNSFWBlur] = useConfigState('appearances.enableNSFWBlur')
+  const [nsfwBlurLevel] = useConfigState('appearances.nsfwBlurLevel')
   const [nsfw] = useGameState(gameId, 'apperance.nsfw')
+  const hideLogo = nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage
 
   useEffect(() => {
     setLocalLogoPosition(logoPosition)
@@ -166,7 +168,7 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
     <div className={cn('w-full h-full relative overflow-hidden shrink-0')}>
       {/* Logo Editing Control Panel */}
       {/* Only visible when editing logo */}
-      {isEditingLogo && (!enableNSFWBlur || !nsfw) && (
+      {isEditingLogo && !hideLogo && (
         <div
           className={cn(
             'absolute top-[10px] left-[10px] z-40 bg-transparent p-3 rounded-lg flex gap-3'
@@ -222,7 +224,7 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
       )}
 
       {/* Logo Layer */}
-      {logoVisible && (!enableNSFWBlur || !nsfw) && (
+      {logoVisible && !hideLogo && (
         <div
           ref={logoRef}
           onMouseDown={handleMouseDown}

--- a/src/renderer/src/components/Librarybar/GameNav.tsx
+++ b/src/renderer/src/components/Librarybar/GameNav.tsx
@@ -1,3 +1,4 @@
+import { NSFWBlurLevel } from '@appTypes/models'
 import { useLocation, useNavigate } from '@tanstack/react-router'
 import { Nav } from '@ui/nav'
 import React from 'react'
@@ -8,12 +9,11 @@ import { GamePropertiesDialog } from '~/components/Game/Config/Properties'
 import { ContextMenu, ContextMenuTrigger } from '~/components/ui/context-menu'
 import { GameImage } from '~/components/ui/game-image'
 import { useConfigState, useGameLocalState, useGameState } from '~/hooks'
-import { cn } from '~/utils'
+import { cn, startGame } from '~/utils'
 import { GameNavCM } from '../contextMenu/GameNavCM'
 import { BatchGameNavCM } from '../GameBatchEditor/BatchGameNavCM'
 import { useGameBatchEditorStore } from '../GameBatchEditor/store'
 import { useTheme } from '../ThemeProvider'
-import { startGame } from '~/utils'
 
 export function GameNav({
   gameId,
@@ -27,7 +27,7 @@ export function GameNav({
   const [highlightLocalGames] = useConfigState('game.gameList.highlightLocalGames')
   const [markLocalGames] = useConfigState('game.gameList.markLocalGames')
   const [nsfw] = useGameState(gameId, 'apperance.nsfw')
-  const [enableNSFWBlur] = useConfigState('appearances.enableNSFWBlur')
+  const [nsfwBlurLevel] = useConfigState('appearances.nsfwBlurLevel')
   const isDarkMode = useTheme().isDark
   const location = useLocation()
   const navigate = useNavigate()
@@ -156,7 +156,7 @@ export function GameNav({
                     }
                   />
                 </div>
-                {nsfw && enableNSFWBlur ? (
+                {nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImageAndTitle ? (
                   <div className="relative w-[188px] truncate">
                     <span className="group-hover/gamenav:opacity-0">{obfuscatedGameName}</span>
                     <span className="absolute top-0 left-0 w-full truncate opacity-0 group-hover/gamenav:opacity-100">

--- a/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
@@ -1,3 +1,4 @@
+import { NSFWBlurLevel } from '@appTypes/models'
 import { useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -34,7 +35,7 @@ export function BigGamePoster({
   const [playTime] = useGameState(gameId, 'record.playTime')
   const [gameName] = useGameState(gameId, 'metadata.name')
   const [nsfw] = useGameState(gameId, 'apperance.nsfw')
-  const [enableNSFWBlur] = useConfigState('appearances.enableNSFWBlur')
+  const [nsfwBlurLevel] = useConfigState('appearances.nsfwBlurLevel')
   const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = useState(false)
   const [isPlayTimeEditorDialogOpen, setIsPlayTimeEditorDialogOpen] = useState(false)
   const [isNameEditorDialogOpen, setIsNameEditorDialogOpen] = useState(false)
@@ -42,7 +43,6 @@ export function BigGamePoster({
   const [showPlayButtonOnPoster] = useConfigState('appearances.showcase.showPlayButtonOnPoster')
   const { t } = useTranslation('game')
 
-  const blur = nsfw && enableNSFWBlur
   const name = gameData?.name ?? ''
   const stringToBase64 = (str: string): string =>
     btoa(String.fromCharCode(...new TextEncoder().encode(str)))
@@ -122,7 +122,7 @@ export function BigGamePoster({
                   onClick={handleGameClick}
                   gameId={gameId}
                   type="background"
-                  blur={blur}
+                  blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
                   blurType="bigposter"
                   className={cn(
                     'h-[222px] aspect-[3/2] cursor-pointer select-none object-cover rounded-lg bg-accent/30',
@@ -222,7 +222,7 @@ export function BigGamePoster({
             </div>
 
             <div className="text-xs cursor-pointer select-none text-foreground hover:underline decoration-foreground truncate w-[333px] text-center">
-              {blur ? (
+              {nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImageAndTitle ? (
                 <>
                   <span className="block group-hover:hidden truncate">{obfuscatedName}</span>
                   <span className="hidden group-hover:block truncate">{name}</span>

--- a/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/CollectionPoster.tsx
@@ -1,11 +1,12 @@
-import { GameImage } from '~/components/ui/game-image'
-import { useEffect, useRef, useState } from 'react'
+import { NSFWBlurLevel } from '@appTypes/models'
 import { useRouter } from '@tanstack/react-router'
+import { useEffect, useRef, useState } from 'react'
 import { HoverCardAnimation } from '~/components/animations/HoverCard'
 import { CollectionCM } from '~/components/contextMenu/CollectionCM'
+import { useGameBatchEditorStore } from '~/components/GameBatchEditor/store'
+import { GameImage } from '~/components/ui/game-image'
 import { useConfigState, useGameState } from '~/hooks'
 import { useGameCollectionStore } from '~/stores'
-import { useGameBatchEditorStore } from '~/components/GameBatchEditor/store'
 import { cn } from '~/utils'
 import {
   attachClosestEdge,
@@ -74,7 +75,7 @@ export function CollectionPoster({
   const gameId = collections[collectionId].games[0]
   const collectionGames = collections[collectionId].games
   const [nsfw] = useGameState(gameId, 'apperance.nsfw')
-  const [enableNSFWBlur] = useConfigState('appearances.enableNSFWBlur')
+  const [nsfwBlurLevel] = useConfigState('appearances.nsfwBlurLevel')
   const length = collectionGames.length
 
   // Batch mode and selection state
@@ -213,7 +214,7 @@ export function CollectionPoster({
                 <GameImage
                   gameId={gameId}
                   type="cover"
-                  blur={nsfw && enableNSFWBlur}
+                  blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
                   alt={gameId}
                   className={cn('w-[155px] h-[155px] cursor-pointer object-cover', className)}
                   draggable="false"

--- a/src/renderer/src/components/Showcase/posters/GamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/GamePoster.tsx
@@ -1,3 +1,4 @@
+import { NSFWBlurLevel } from '@appTypes/models'
 import { useNavigate } from '@tanstack/react-router'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -81,7 +82,7 @@ export function GamePoster({
   const [playTime] = useGameState(gameId, 'record.playTime')
   const [gameName] = useGameState(gameId, 'metadata.name')
   const [nsfw] = useGameState(gameId, 'apperance.nsfw')
-  const [enableNSFWBlur] = useConfigState('appearances.enableNSFWBlur')
+  const [nsfwBlurLevel] = useConfigState('appearances.nsfwBlurLevel')
   const [isAddCollectionDialogOpen, setIsAddCollectionDialogOpen] = useState(false)
   const [isPlayTimeEditorDialogOpen, setIsPlayTimeEditorDialogOpen] = useState(false)
   const [isNameEditorDialogOpen, setIsNameEditorDialogOpen] = useState(false)
@@ -94,7 +95,6 @@ export function GamePoster({
   const [previewState, setPreviewState] = useState<PreviewState>({ type: 'idle' })
   const [showPlayButtonOnPoster] = useConfigState('appearances.showcase.showPlayButtonOnPoster')
 
-  const blur = nsfw && enableNSFWBlur
   const name = gameData?.name ?? ''
   const stringToBase64 = (str: string): string =>
     btoa(String.fromCharCode(...new TextEncoder().encode(str)))
@@ -244,7 +244,7 @@ export function GamePoster({
                       draggable="false"
                       gameId={gameId}
                       type="cover"
-                      blur={blur}
+                      blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
                       alt={gameId}
                       className={cn(
                         'w-[148px] aspect-[2/3] cursor-pointer select-none object-cover rounded-lg',
@@ -349,7 +349,7 @@ export function GamePoster({
                 </div>
 
                 <div className="text-xs text-foreground truncate cursor-pointer select-none hover:underline w-[148px] text-center decoration-foreground">
-                  {blur ? (
+                  {nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImageAndTitle ? (
                     <>
                       <span className="block group-hover:hidden truncate">{obfuscatedName}</span>
                       <span className="hidden group-hover:block truncate">{name}</span>

--- a/src/renderer/src/pages/Light.tsx
+++ b/src/renderer/src/pages/Light.tsx
@@ -1,13 +1,14 @@
-import { useEffect, useRef, useState } from 'react'
+import { NSFWBlurLevel } from '@appTypes/models'
+import defaultBackground from '@assets/defaultBackground.webp'
 import { useLocation } from '@tanstack/react-router'
+import { CrossfadeImage } from '@ui/cross-fade-image'
+import { useEffect, useRef, useState } from 'react'
+import { create } from 'zustand'
+import { useTheme } from '~/components/ThemeProvider'
 import { useConfigState, useGameState } from '~/hooks'
 import { useAttachmentStore } from '~/stores'
 import { sortGames, useGameCollectionStore } from '~/stores/game'
-import { CrossfadeImage } from '@ui/cross-fade-image'
 import { cn } from '~/utils'
-import { useTheme } from '~/components/ThemeProvider'
-import { create } from 'zustand'
-import defaultBackground from '@assets/defaultBackground.webp'
 
 // eslint-disable-next-line
 export const useLightStore = create<{
@@ -32,7 +33,7 @@ export function Light(): React.JSX.Element {
   const [lightGlassOpacity] = useConfigState('appearances.glass.light.opacity')
   const [glassBlur, setGlassBlur] = useState(darkGlassBlur)
   const [glassOpacity, setGlassOpacity] = useState(darkGlassOpacity)
-  const [enableNSFWBlur] = useConfigState('appearances.enableNSFWBlur')
+  const [nsfwBlurLevel] = useConfigState('appearances.nsfwBlurLevel')
   const [nsfw] = useGameState(gameId, 'apperance.nsfw')
   const detailBackgroundRef = useRef<HTMLDivElement>(null)
   const parallaxContainerRef = useRef<HTMLDivElement>(null)
@@ -218,7 +219,7 @@ export function Light(): React.JSX.Element {
               <CrossfadeImage
                 src={imageUrl}
                 className={cn(`w-full h-auto max-h-(--header-max-height) object-top object-cover`)}
-                blur={enableNSFWBlur && nsfw}
+                blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
                 duration={500}
                 onError={() => {
                   if (customBackground) {

--- a/src/renderer/src/pages/Record/GameRankingItem.tsx
+++ b/src/renderer/src/pages/Record/GameRankingItem.tsx
@@ -1,3 +1,4 @@
+import { NSFWBlurLevel } from '@appTypes/models'
 import { generateUUID } from '@appUtils'
 import { useRouter } from '@tanstack/react-router'
 import { usePositionButtonStore } from '~/components/Librarybar/PositionButton'
@@ -20,7 +21,7 @@ export function GameRankingItem({
 }: GameRankingItemProps): React.JSX.Element {
   const [gameName] = useGameState(gameId, 'metadata.name')
   const [nsfw] = useGameState(gameId, 'apperance.nsfw')
-  const [enableNSFWBlur] = useConfigState('appearances.enableNSFWBlur')
+  const [nsfwBlurLevel] = useConfigState('appearances.nsfwBlurLevel')
   const router = useRouter()
   const setLazyloadMark = usePositionButtonStore((state) => state.setLazyloadMark)
 
@@ -48,7 +49,7 @@ export function GameRankingItem({
       <GameImage
         gameId={gameId}
         type={'cover'}
-        blur={nsfw && enableNSFWBlur}
+        blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
         blurType="smallposter"
         className="object-cover w-10 h-10 rounded-md"
         fallback={<div className="w-10 h-10 rounded-md bg-primary" />}

--- a/src/renderer/src/pages/Record/ScoreReport.tsx
+++ b/src/renderer/src/pages/Record/ScoreReport.tsx
@@ -1,3 +1,7 @@
+import { CalendarIcon, ClockIcon, GamepadIcon, Trophy } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import AutoSizer from 'react-virtualized-auto-sizer'
+import { FixedSizeList } from 'react-window'
 import { Badge } from '~/components/ui/badge'
 import { Card } from '~/components/ui/card'
 import { GameImage } from '~/components/ui/game-image'
@@ -7,11 +11,8 @@ import {
   HoverCardPortal,
   HoverCardTrigger
 } from '~/components/ui/hover-card'
-import { CalendarIcon, ClockIcon, GamepadIcon, Trophy } from 'lucide-react'
-import { useTranslation } from 'react-i18next'
-import AutoSizer from 'react-virtualized-auto-sizer'
-import { FixedSizeList } from 'react-window'
 
+import { NSFWBlurLevel } from '@appTypes/models'
 import { useConfigState, useGameState } from '~/hooks'
 import { getGamePlayTime, getGameStore, useGameRegistry } from '~/stores/game'
 import { getGamesByScoreRange } from '~/stores/game/recordUtils'
@@ -24,7 +25,7 @@ function GameScoreCard({ gameId }: { gameId: string }): React.JSX.Element {
   const gameInfo = gameMetaIndex[gameId] || { name: t('score.gameInfo.unknown') }
   const [score] = useGameState(gameId, 'record.score')
   const [nsfw] = useGameState(gameId, 'apperance.nsfw')
-  const [enableNSFWBlur] = useConfigState('appearances.enableNSFWBlur')
+  const [nsfwBlurLevel] = useConfigState('appearances.nsfwBlurLevel')
   const playTime = getGamePlayTime(gameId)
 
   return (
@@ -34,7 +35,7 @@ function GameScoreCard({ gameId }: { gameId: string }): React.JSX.Element {
           <div className="relative group">
             <GamePoster
               gameId={gameId}
-              blur={nsfw && enableNSFWBlur}
+              blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
               className={cn(
                 'object-cover rounded-lg shadow-md',
                 'w-[120px] h-[180px] cursor-pointer object-cover',
@@ -55,7 +56,7 @@ function GameScoreCard({ gameId }: { gameId: string }): React.JSX.Element {
               gameId={gameId}
               type="background"
               alt={gameId}
-              blur={nsfw && enableNSFWBlur}
+              blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
               className="object-cover w-full h-full rounded-lg"
               draggable="false"
             />

--- a/src/types/models/config.ts
+++ b/src/types/models/config.ts
@@ -1,3 +1,9 @@
+export enum NSFWBlurLevel {
+  Off = 0,
+  BlurImage = 1,
+  BlurImageAndTitle = 2,
+  HideGame = 3 // TODO: reserved for future implementation
+}
 export interface configDocs {
   general: {
     openAtLogin: boolean
@@ -81,7 +87,7 @@ export interface configDocs {
         opacity: number
       }
     }
-    enableNSFWBlur: boolean
+    nsfwBlurLevel: NSFWBlurLevel
     fonts: {
       family: string
       size: number
@@ -291,7 +297,7 @@ export const DEFAULT_CONFIG_VALUES: Readonly<configDocs> = {
         opacity: 0.9
       }
     },
-    enableNSFWBlur: true,
+    nsfwBlurLevel: NSFWBlurLevel.Off,
     fonts: {
       family: 'LXGW WenKai Mono',
       size: 1, // in rem


### PR DESCRIPTION
弃用了原先boolean类型的enableNSFWBlur配置字段，使用新的枚举字段记录屏蔽级别，目前共三个级别：不屏蔽 / 屏蔽图片 / 屏蔽图片与标题。

> 隐藏游戏先画个饼在那放着