### PR TITLE
fix: Trim whitespaces and line breaks from getchu game description string in metadata retrieval

### DIFF
--- a/src/main/features/scraper/providers/getchu/common.ts
+++ b/src/main/features/scraper/providers/getchu/common.ts
@@ -181,7 +181,7 @@ export async function getGetchuGameMetadata(identifier: ScraperIdentifier): Prom
       to: 'UNICODE',
       from: 'EUCJP'
     })
-    const descriptionStr = Encoding.codeToString(unicodeArray)
+    const descriptionStr = Encoding.codeToString(unicodeArray).replace(/^\s+|\s+$/g, '')
 
     resolve({
       name: name,


### PR DESCRIPTION
Some of game descriptions retrieved from Getchu contain a lot of continuous heading and trailing whitespace characters making the layout look messy.
This PR eliminates those redundant characters.