### PR TITLE
Opti: playtime record chart

### DIFF
--- a/src/renderer/src/components/Game/Record/ChartCard.tsx
+++ b/src/renderer/src/components/Game/Record/ChartCard.tsx
@@ -1,11 +1,12 @@
 import { DateTimeInput } from '@ui/date-input'
-import { cn } from '~/utils'
-import { getGamePlayTimeByDateRange, getGameStartAndEndDate } from '~/stores/game'
-import { useState, useEffect } from 'react'
-import { TimerChart } from './TimerChart'
 import { isEqual } from 'lodash'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { StepperInput } from '~/components/ui/input'
 import { SeparatorDashed } from '~/components/ui/separator-dashed'
+import { getGamePlayTimeByDateRange, getGameStartAndEndDate } from '~/stores/game'
+import { cn } from '~/utils'
+import { TimerChart } from './TimerChart'
 
 export function ChartCard({
   gameId,
@@ -18,6 +19,7 @@ export function ChartCard({
   const timers = getGameStartAndEndDate(gameId)
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
+  const [minValue, setMinValue] = useState(0)
   const [playTimeByDateRange, setPlayTimeByDateRange] = useState<Record<string, number>>({})
 
   useEffect(() => {
@@ -62,6 +64,18 @@ export function ChartCard({
               onChange={(e) => setEndDate(e.target.value)}
               className={cn('')}
             />
+            <div className="w-px h-9 bg-primary" />
+            <div className={cn('relative flex w-28 items-center')}>
+              <span className="absolute left-2">{'>'}</span>
+              <StepperInput
+                value={minValue}
+                min={0}
+                max={24 * 60}
+                onChange={(e) => setMinValue(Number(e.target.value))}
+                inputClassName="pl-6 pr-8 w-full"
+              />
+              <span className="absolute right-2">min</span>
+            </div>
           </div>
           {!startDate || !endDate ? (
             t('detail.chart.selectRange')
@@ -73,7 +87,11 @@ export function ChartCard({
             </div>
           ) : (
             <div className={cn('max-h-full rounded-lg py-3', '3xl:max-h-full')}>
-              <TimerChart data={playTimeByDateRange} className={cn('w-full max-h-[30vh] -ml-3')} />
+              <TimerChart
+                data={playTimeByDateRange}
+                minMinutes={minValue}
+                className={cn('w-full max-h-[30vh] -ml-3')}
+              />
             </div>
           )}
         </>

--- a/src/renderer/src/components/Game/Record/TimerChart.tsx
+++ b/src/renderer/src/components/Game/Record/TimerChart.tsx
@@ -1,7 +1,7 @@
-import type { ValueType } from 'recharts/types/component/DefaultTooltipContent'
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from '~/components/ui/chart'
 import { useTranslation } from 'react-i18next'
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
+import type { ValueType } from 'recharts/types/component/DefaultTooltipContent'
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from '~/components/ui/chart'
 import { cn } from '~/utils'
 
 interface DailyPlayTime {
@@ -16,10 +16,12 @@ interface ChartData {
 export const TimerChart = ({
   data,
   className,
+  minMinutes = 0,
   filter0 = true
 }: {
   data: DailyPlayTime
   className?: string
+  minMinutes?: number
   filter0?: boolean
 }): React.JSX.Element => {
   const { t } = useTranslation('game')
@@ -36,7 +38,7 @@ export const TimerChart = ({
         date,
         playTime: playTime / 1000 / 60 // Converting milliseconds to minutes
       }))
-      .filter((item) => item.playTime > 0) // Filter out days with 0 hours of gameplay
+      .filter((item) => item.playTime > minMinutes) // Filter out days less than `minMinutes` hours of gameplay
   } else {
     chartData = Object.entries(data).map(([date, playTime]) => ({
       date,

--- a/src/renderer/src/components/ui/input.tsx
+++ b/src/renderer/src/components/ui/input.tsx
@@ -12,6 +12,13 @@ export interface ClearableInputProps extends InputProps {
   onClear?: () => void
 }
 
+interface StepperInputProps extends InputProps {
+  inputClassName?: string
+  step?: number
+  min?: number
+  max?: number
+}
+
 function Input({ className, type, ...props }: React.ComponentProps<'input'>): React.JSX.Element {
   return (
     <input
@@ -78,7 +85,70 @@ const ClearableInput = React.forwardRef<HTMLInputElement, ClearableInputProps>(
   }
 )
 
+const StepperInput = React.forwardRef<HTMLInputElement, StepperInputProps>(
+  ({ className, inputClassName, step = 1, min, max, value, onChange, ...props }, ref) => {
+    const numericValue = Number(value) || 0
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+      let value = Number(e.target.value)
+
+      if (min !== undefined && value < min) value = min
+      if (max !== undefined && value > max) value = max
+
+      onChange?.({ ...e, target: { ...e.target, value: String(value) } })
+    }
+
+    const handleStep = (delta: number, e?: React.MouseEvent | React.KeyboardEvent): void => {
+      const newValue = numericValue + (e?.shiftKey ? delta * 10 : delta)
+      const event = {
+        target: { value: String(newValue) }
+      } as React.ChangeEvent<HTMLInputElement>
+      handleChange(event)
+    }
+
+    return (
+      <div className={cn('relative w-full group', className)}>
+        <Input
+          ref={ref}
+          type="number"
+          value={value}
+          onChange={handleChange}
+          className={cn(
+            'pr-10 appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none',
+            inputClassName
+          )}
+          {...props}
+        />
+        <div
+          className={cn(
+            'absolute right-1 top-1/2 -translate-y-1/2 hidden group-focus-within:flex flex-col z-10',
+            'bg-popover/(--glass-opacity) backdrop-filter backdrop-blur-[32px] rounded-md'
+          )}
+        >
+          <Button
+            variant="outline"
+            size="icon"
+            className="w-8 h-8 p-0 flex items-center justify-center"
+            onClick={(e) => handleStep(step, e)}
+          >
+            <span className="icon-[mdi--keyboard-arrow-up] w-5 h-5"></span>
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="w-8 h-8 p-0 flex items-center justify-center"
+            onClick={(e) => handleStep(-step, e)}
+          >
+            <span className="icon-[mdi--keyboard-arrow-down] w-5 h-5"></span>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+)
+
 Input.displayName = 'Input'
 ClearableInput.displayName = 'ClearableInput'
+StepperInput.displayName = 'StepperInput'
 
-export { ClearableInput, Input }
+export { ClearableInput, Input, StepperInput }

--- a/src/renderer/src/stores/game/gameUtils.ts
+++ b/src/renderer/src/stores/game/gameUtils.ts
@@ -594,8 +594,15 @@ export function getGameStartAndEndDate(gameId: string): { start: string; end: st
       return `${year}-${month}-${day}`
     }
 
-    const start = new Date(timers[0].start)
-    const end = new Date(timers[timers.length - 1].end)
+    const startTimestamps = timers.map((t) => Date.parse(t.start)).filter((ts) => !isNaN(ts))
+    const endTimestamps = timers.map((t) => Date.parse(t.end)).filter((ts) => !isNaN(ts))
+
+    if (endTimestamps.length === 0 || startTimestamps.length === 0) {
+      return { start: '', end: '' }
+    }
+
+    const start = new Date(Math.min(...startTimestamps))
+    const end = new Date(Math.max(...endTimestamps))
 
     return {
       start: formatDate(start),


### PR DESCRIPTION
优化了游戏记录页的时间图表：
- 修复了时间范围的自动计算问题（由于新增的游玩记录编辑器可能引入乱序的游玩记录）
- 增加了过滤功能，在图表中过滤游玩时间小于一定值的日期