### PR TITLE
fix: preserve legacy fuzzy play time in play time editor

### DIFF
--- a/src/renderer/locales/en/game.json
+++ b/src/renderer/locales/en/game.json
@@ -351,6 +351,7 @@
       "title": "Game Timer",
       "addTimer": "Add Timer",
       "timersList": "Timers List",
+      "fuzzyTime": "Time Not Tracked by Timers",
       "noTimers": "No timer records",
       "totalPlayTime": "Total Play Time",
       "startTime": "Start",

--- a/src/renderer/locales/ja/game.json
+++ b/src/renderer/locales/ja/game.json
@@ -351,6 +351,7 @@
       "title": "ゲームタイマー",
       "addTimer": "タイマーを追加",
       "timersList": "タイマーリスト",
+      "fuzzyTime": "タイマー未記録のプレイ時間",
       "noTimers": "タイマー記録がありません",
       "totalPlayTime": "総プレイ時間",
       "startTime": "開始",

--- a/src/renderer/locales/zh-CN/game.json
+++ b/src/renderer/locales/zh-CN/game.json
@@ -351,6 +351,7 @@
       "title": "游戏计时器",
       "addTimer": "添加计时器",
       "timersList": "计时器列表",
+      "fuzzyTime": "计时器未记录游玩时间",
       "noTimers": "没有计时器记录",
       "totalPlayTime": "总游戏时长",
       "startTime": "开始",

--- a/src/renderer/locales/zh-TW/game.json
+++ b/src/renderer/locales/zh-TW/game.json
@@ -351,6 +351,7 @@
       "title": "遊戲計時器",
       "addTimer": "添加計時器",
       "timersList": "計時器列表",
+      "fuzzyTime": "計時器未記錄遊玩時間",
       "noTimers": "沒有計時器記錄",
       "totalPlayTime": "總遊戲時長",
       "startTime": "開始",

--- a/src/renderer/src/components/Game/Config/ManageMenu/PlayTimeEditorDialog.tsx
+++ b/src/renderer/src/components/Game/Config/ManageMenu/PlayTimeEditorDialog.tsx
@@ -80,11 +80,17 @@ export function PlayTimeEditorDialog({
   }
 
   const handleSave = (): void => {
+    // TEMPORARY: preserve fuzzy play time for compatibility with old data
+    // (e.g. imported from Steam, previous manual edits)
+    // should be removed in the future when related issues are resolved
+    const oldTimersTime = calculateTotalPlayTime(record.timers)
+    const fuzzyTime = Math.max(0, record.playTime - oldTimersTime)
+
     const playTimeMs = calculateTotalPlayTime(timers)
     setRecord({
       ...record,
       timers: timers,
-      playTime: playTimeMs
+      playTime: playTimeMs + fuzzyTime
     })
     setIsOpen(false)
   }

--- a/src/renderer/src/components/Game/Config/ManageMenu/PlayTimeEditorDialog.tsx
+++ b/src/renderer/src/components/Game/Config/ManageMenu/PlayTimeEditorDialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { Button } from '~/components/ui/button'
 import { Card } from '~/components/ui/card'
 import { Dialog, DialogContent } from '~/components/ui/dialog'
+import { StepperInput } from '~/components/ui/input'
 import { useGameState } from '~/hooks'
 import { cn } from '~/utils'
 import { TimerEditDialog } from './TimerEditDialog'
@@ -19,7 +20,20 @@ export function PlayTimeEditorDialog({
   const { t } = useTranslation('game')
   const [record, setRecord] = useGameState(gameId, 'record')
 
+  const calculateTotalPlayTime = (timersList: { start: string; end: string }[]): number => {
+    return timersList.reduce((total, timer) => {
+      if (!timer.start || !timer.end) return total
+      const start = new Date(timer.start).getTime()
+      const end = new Date(timer.end).getTime()
+      return total + Math.max(0, end - start)
+    }, 0) // milliseconds
+  }
+
   const [timers, setTimers] = useState<{ start: string; end: string }[]>(record.timers || [])
+  const [fuzzyTime, setFuzzyTime] = useState(() => {
+    const oldTimersTime = calculateTotalPlayTime(record.timers)
+    return Math.max(0, record.playTime - oldTimersTime) / 1000 / 60
+  })
 
   const [isTimerDialogOpen, setIsTimerDialogOpen] = useState(false)
   const [editingTimer, setEditingTimer] = useState<{ start: string; end: string } | undefined>(
@@ -38,15 +52,6 @@ export function PlayTimeEditorDialog({
   const calculateDuration = (start: string, end: string): number => {
     if (!start || !end) return 0
     return Math.floor((new Date(end).getTime() - new Date(start).getTime()) / 1000 / 60) // minutes
-  }
-
-  const calculateTotalPlayTime = (timersList: { start: string; end: string }[]): number => {
-    return timersList.reduce((total, timer) => {
-      if (!timer.start || !timer.end) return total
-      const start = new Date(timer.start).getTime()
-      const end = new Date(timer.end).getTime()
-      return total + Math.max(0, end - start)
-    }, 0) // milliseconds
   }
 
   const openAddTimer = (): void => {
@@ -80,17 +85,13 @@ export function PlayTimeEditorDialog({
   }
 
   const handleSave = (): void => {
-    // TEMPORARY: preserve fuzzy play time for compatibility with old data
+    // preserve fuzzy play time for compatibility with old data
     // (e.g. imported from Steam, previous manual edits)
-    // should be removed in the future when related issues are resolved
-    const oldTimersTime = calculateTotalPlayTime(record.timers)
-    const fuzzyTime = Math.max(0, record.playTime - oldTimersTime)
-
     const playTimeMs = calculateTotalPlayTime(timers)
     setRecord({
       ...record,
       timers: timers,
-      playTime: playTimeMs + fuzzyTime
+      playTime: playTimeMs + fuzzyTime * 60 * 1000
     })
     setIsOpen(false)
   }
@@ -112,7 +113,7 @@ export function PlayTimeEditorDialog({
           </Button>
 
           {/* Timer List */}
-          <div className="mb-4">
+          <div className="mb-2">
             <h4 className="text-md font-semibold mb-2">{t('detail.timersEditor.timersList')}</h4>
             {timers.length === 0 ? (
               <div className="text-muted-foreground p-4 text-center bg-muted rounded-md">
@@ -166,11 +167,31 @@ export function PlayTimeEditorDialog({
             )}
           </div>
 
+          {/* Fuzzy Time Input */}
+          <div>
+            <h4 className="text-md font-semibold mb-2">{t('detail.timersEditor.fuzzyTime')}</h4>
+            <div className="flex gap-3 items-center">
+              <div className={cn('relative flex w-1/3 items-center')}>
+                <StepperInput
+                  value={fuzzyTime}
+                  min={0}
+                  steps={{ default: 5, shift: 600, alt: 60, ctrl: 1 }}
+                  onChange={(e) => setFuzzyTime(Number(e.target.value))}
+                  inputClassName="pl-4 pr-8 w-full"
+                />
+                <span className="absolute right-2">min</span>
+              </div>
+              <div>{`(${t('{{date, gameTime}}', { date: Number(fuzzyTime) * 60 * 1000 })})`}</div>
+            </div>
+          </div>
+
           <div className="flex items-center justify-between border-t pt-4 mt-2">
             {/* Total Play Time */}
             <div className="text-md">
               <span className="font-medium">{t('detail.timersEditor.totalPlayTime')}:</span>{' '}
-              {t('{{date, gameTime}}', { date: calculateTotalPlayTime(timers) })}
+              {t('{{date, gameTime}}', {
+                date: calculateTotalPlayTime(timers) + fuzzyTime * 60 * 1000
+              })}
             </div>
             {/* Save and Cancel Buttons */}
             <div className="flex space-x-2">

--- a/src/renderer/src/components/Game/Record/ChartCard.tsx
+++ b/src/renderer/src/components/Game/Record/ChartCard.tsx
@@ -71,6 +71,7 @@ export function ChartCard({
                 value={minValue}
                 min={0}
                 max={24 * 60}
+                steps={{ default: 1, shift: 10 }}
                 onChange={(e) => setMinValue(Number(e.target.value))}
                 inputClassName="pl-6 pr-8 w-full"
               />


### PR DESCRIPTION
这是关于 #348 中提及问题的一个临时补丁，在新版游玩时间编辑器的保存过程中保留了之前设置的未被计时器追踪的游玩时间信息，同时支持对该部分时间进行独立设定。