### PR TITLE
Opti: navigation in record page (settings page)

### DIFF
--- a/src/renderer/src/app/router.tsx
+++ b/src/renderer/src/app/router.tsx
@@ -1,23 +1,23 @@
 import {
-  createRouter,
+  createHashHistory,
   createRootRoute,
   createRoute,
-  redirect,
-  createHashHistory
+  createRouter,
+  redirect
 } from '@tanstack/react-router'
-import { RootLayout } from '../layouts/RootLayout'
-import { Library } from '~/pages/Library'
-import { Record } from '~/pages/Record'
+import { Game } from '~/components/Game'
+import { Showcase } from '~/components/Showcase'
+import { CollectionGames } from '~/components/Showcase/CollectionGames'
+import { CollectionPage } from '~/components/Showcase/CollectionPage'
 import { Config } from '~/pages/Config'
 import { GameScannerManager } from '~/pages/GameScannerManager'
-import { TransformerManager } from '~/pages/TransformerManager'
+import { Library } from '~/pages/Library'
 import { Plugin } from '~/pages/Plugin/main'
+import { Record } from '~/pages/Record'
+import { TransformerManager } from '~/pages/TransformerManager'
 import { Icon } from '~/pages/arts/Icon'
 import { Logo } from '~/pages/arts/Logo'
-import { Showcase } from '~/components/Showcase'
-import { CollectionPage } from '~/components/Showcase/CollectionPage'
-import { Game } from '~/components/Game'
-import { CollectionGames } from '~/components/Showcase/CollectionGames'
+import { RootLayout } from '../layouts/RootLayout'
 
 const hashHistory = createHashHistory()
 
@@ -86,7 +86,12 @@ const recordRoute = createRoute({
 const configRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/config',
-  component: Config
+  component: Config,
+  validateSearch: (search: Record<string, unknown>) => {
+    return {
+      tab: typeof search.tab === 'string' ? search.tab : 'general'
+    }
+  }
 })
 
 const scannerRoute = createRoute({

--- a/src/renderer/src/app/router.tsx
+++ b/src/renderer/src/app/router.tsx
@@ -80,7 +80,20 @@ const libraryCollectionGamesRoute = createRoute({
 const recordRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/record',
-  component: Record
+  component: Record,
+  validateSearch: (search) => {
+    const tab = typeof search.tab === 'string' ? search.tab : 'overview'
+    const date =
+      typeof search.date === 'string' && !isNaN(Date.parse(search.date))
+        ? search.date
+        : new Date().toISOString()
+    const year =
+      typeof search.year === 'string' && /^\d{4}$/.test(search.year)
+        ? search.year
+        : String(new Date().getFullYear())
+
+    return { tab, date, year }
+  }
 })
 
 const configRoute = createRoute({

--- a/src/renderer/src/components/Game/Record/TimerChart.tsx
+++ b/src/renderer/src/components/Game/Record/TimerChart.tsx
@@ -1,7 +1,9 @@
+import { useRouter } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from 'recharts'
 import type { ValueType } from 'recharts/types/component/DefaultTooltipContent'
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '~/components/ui/chart'
+import { parseLocalDate } from '~/stores/game/recordUtils'
 import { cn } from '~/utils'
 
 interface DailyPlayTime {
@@ -26,8 +28,23 @@ export const TimerChart = ({
   filter0?: boolean
 }): React.JSX.Element => {
   const { t } = useTranslation('game')
+  const router = useRouter()
   const formatGameTime = (time: number): string => {
     return t('utils:format.gameTime', { time })
+  }
+
+  const handleBarClick = (entry: (typeof chartData)[number]): void => {
+    const dateUTC = parseLocalDate(entry.date) // YYYY-MM-DD
+    const isoDate = dateUTC.toISOString()
+
+    router.navigate({
+      to: '/record',
+      search: {
+        tab: 'weekly',
+        date: isoDate,
+        year: dateUTC.getFullYear().toString()
+      }
+    })
   }
 
   // Converting data into the format Recharts needs
@@ -106,6 +123,8 @@ export const TimerChart = ({
             <Cell
               key={`${entry.date}-${entry.group}`}
               fill={entry.group === 0 ? 'var(--primary)' : 'var(--secondary)'}
+              onClick={() => handleBarClick(entry)}
+              cursor="pointer"
             />
           ))}
         </Bar>

--- a/src/renderer/src/pages/Config/main.tsx
+++ b/src/renderer/src/pages/Config/main.tsx
@@ -1,8 +1,8 @@
+import { useRouter, useSearch } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
 import { Button } from '~/components/ui/button'
 import { ScrollArea } from '~/components/ui/scroll-area'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
-import { useTranslation } from 'react-i18next'
-import { useRouter } from '@tanstack/react-router'
 import { cn } from '~/utils'
 import { About } from './About'
 import { Advanced } from './Advanced'
@@ -18,9 +18,18 @@ import { Theme } from './Theme'
 export function Config({ className }: { className?: string }): React.JSX.Element {
   const { t } = useTranslation('config')
   const router = useRouter()
+  const { tab } = useSearch({ from: '/config' })
 
   const handleGoBack = (): void => {
     router.history.back()
+  }
+
+  const handleTabChange = (value: string): void => {
+    router.navigate({
+      to: '/config',
+      search: { tab: value },
+      replace: true
+    })
   }
 
   return (
@@ -40,7 +49,7 @@ export function Config({ className }: { className?: string }): React.JSX.Element
             </Button>
           </div>
 
-          <Tabs defaultValue="general" className="w-full">
+          <Tabs value={tab} onValueChange={handleTabChange} className="w-full">
             <TabsList className="mb-4">
               <TabsTrigger value="general">{t('general.title')}</TabsTrigger>
               <TabsTrigger value="appearances">{t('appearances.title')}</TabsTrigger>

--- a/src/renderer/src/pages/Record/MonthlyReport.tsx
+++ b/src/renderer/src/pages/Record/MonthlyReport.tsx
@@ -1,7 +1,7 @@
 import { useRouter, useSearch } from '@tanstack/react-router'
 import { CalendarIcon, ChevronLeft, ChevronRight, Clock, Trophy } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 import { Button, buttonVariants } from '~/components/ui/button'
 import { Calendar } from '~/components/ui/calendar'
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
@@ -67,7 +67,13 @@ export function MonthlyReport(): React.JSX.Element {
 
   const currentMonthName = getLocalizedMonth(selectedDate.getMonth())
 
-  // Preparing data for charts
+  // Data for charts, not weekly but daily
+  const dailyChartData = Object.entries(monthData.dailyPlayTime).map(([date, playTime]) => ({
+    date: date,
+    playTime: playTime / 3600000
+  }))
+
+  // Preparing data for charts (replaced by the above one)
   const weeklyChartData = monthData.weeklyPlayTime
     .map((item) => ({
       week: t('monthly.chart.weekFormat', { week: item.week }),
@@ -209,30 +215,32 @@ export function MonthlyReport(): React.JSX.Element {
           </CardHeader>
           <CardContent className="pt-0">
             <ChartContainer config={chartConfig} className="h-[320px] w-full">
-              <AreaChart data={weeklyChartData}>
+              <BarChart data={dailyChartData}>
                 <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                <XAxis dataKey="week" tickLine={false} axisLine={false} tickMargin={10} />
+                <XAxis
+                  dataKey="date"
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={10}
+                  tickFormatter={(value) => value.slice(8)} // Day only
+                />
                 <YAxis tickLine={false} axisLine={false} tickMargin={10} />
                 <ChartTooltip
                   content={(props) => (
                     <ChartTooltipContent
                       {...props}
                       formatter={(value) => formatGameTime((value as number) * 3600000)}
-                      labelFormatter={(week) => `${week}`}
                       hideIndicator={false}
                       color="var(--primary)"
                     />
                   )}
                 />
-                <Area
-                  type="monotone"
+                <Bar
                   dataKey="playTime"
-                  stroke="var(--primary)"
-                  strokeWidth={2}
-                  fillOpacity={0.3}
                   fill="var(--primary)"
+                  radius={[4, 4, 0, 0]}
                 />
-              </AreaChart>
+              </BarChart>
             </ChartContainer>
           </CardContent>
         </Card>

--- a/src/renderer/src/pages/Record/MonthlyReport.tsx
+++ b/src/renderer/src/pages/Record/MonthlyReport.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '~/components/ui/chart'
 import { Separator } from '~/components/ui/separator'
 
-import { getMonthlyPlayData } from '~/stores/game/recordUtils'
+import { getMonthlyPlayData, parseLocalDate } from '~/stores/game/recordUtils'
 import { cn } from '~/utils'
 import { GameRankingItem } from './GameRankingItem'
 import { StatCard } from './StatCard'
@@ -27,6 +27,33 @@ export function MonthlyReport(): React.JSX.Element {
         tab: 'monthly',
         date: newDate.toISOString(),
         year: newDate.getFullYear().toString()
+      }
+    })
+  }
+  const handleBarClick = (data: any): void => {
+    type DailyChartItem = (typeof dailyChartData)[number]
+    const { date } = data.payload as DailyChartItem
+    const dateUTC = parseLocalDate(date) // YYYY-MM-DD
+    const isoDate = dateUTC.toISOString()
+
+    router.navigate({
+      to: '/record',
+      search: {
+        tab: 'weekly',
+        date: isoDate,
+        year: dateUTC.getFullYear().toString()
+      }
+    })
+  }
+  const handleDayClick = (day: Date): void => {
+    const isoDate = day.toISOString()
+
+    router.navigate({
+      to: '/record',
+      search: {
+        tab: 'weekly',
+        date: isoDate,
+        year: day.getFullYear().toString()
       }
     })
   }
@@ -238,6 +265,8 @@ export function MonthlyReport(): React.JSX.Element {
                 <Bar
                   dataKey="playTime"
                   fill="var(--primary)"
+                  onClick={handleBarClick}
+                  cursor="pointer"
                   radius={[4, 4, 0, 0]}
                 />
               </BarChart>
@@ -255,6 +284,7 @@ export function MonthlyReport(): React.JSX.Element {
               selected={selectedDate}
               month={selectedDate} // Controls the displayed month
               onMonthChange={(date) => setSelectedDate(date)}
+              onDayClick={handleDayClick}
               className="p-0 rounded-md select-none"
               classNames={{
                 day: cn(

--- a/src/renderer/src/pages/Record/MonthlyReport.tsx
+++ b/src/renderer/src/pages/Record/MonthlyReport.tsx
@@ -1,12 +1,12 @@
+import { useRouter, useSearch } from '@tanstack/react-router'
+import { CalendarIcon, ChevronLeft, ChevronRight, Clock, Trophy } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 import { Button, buttonVariants } from '~/components/ui/button'
 import { Calendar } from '~/components/ui/calendar'
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card'
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '~/components/ui/chart'
 import { Separator } from '~/components/ui/separator'
-import { CalendarIcon, ChevronLeft, ChevronRight, Clock, Trophy } from 'lucide-react'
-import { useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 
 import { getMonthlyPlayData } from '~/stores/game/recordUtils'
 import { cn } from '~/utils'
@@ -16,7 +16,22 @@ import { StatCard } from './StatCard'
 export function MonthlyReport(): React.JSX.Element {
   const { t } = useTranslation('record')
 
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date())
+  const router = useRouter()
+  const search = useSearch({ from: '/record' })
+  const selectedDate = new Date(search.date)
+
+  const setSelectedDate = (newDate: Date): void => {
+    router.navigate({
+      to: '/record',
+      search: {
+        tab: 'monthly',
+        date: newDate.toISOString(),
+        year: newDate.getFullYear().toString()
+      }
+    })
+  }
+
+  // const [selectedDate, setSelectedDate] = useState<Date>(new Date())
   const monthData = getMonthlyPlayData(selectedDate)
 
   const goToPreviousMonth = (): void => {

--- a/src/renderer/src/pages/Record/WeeklyReport.tsx
+++ b/src/renderer/src/pages/Record/WeeklyReport.tsx
@@ -1,20 +1,34 @@
-import { useState } from 'react'
+import { useRouter, useSearch } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 import { Button } from '~/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card'
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '~/components/ui/chart'
 import { Separator } from '~/components/ui/separator'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 
 import { getWeeklyPlayData, parseLocalDate } from '~/stores/game/recordUtils'
 import { GameRankingItem } from './GameRankingItem'
 
 export function WeeklyReport(): React.JSX.Element {
   const { t } = useTranslation('record')
+  const router = useRouter()
+  const search = useSearch({ from: '/record' })
+  const selectedDate = new Date(search.date)
 
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date())
+  const setSelectedDate = (newDate: Date): void => {
+    router.navigate({
+      to: '/record',
+      search: {
+        tab: 'weekly',
+        date: newDate.toISOString(),
+        year: newDate.getFullYear().toString()
+      }
+    })
+  }
+
+  // const [selectedDate, setSelectedDate] = useState<Date>(new Date())
   const weekData = getWeeklyPlayData(selectedDate)
 
   const goToPreviousWeek = (): void => {

--- a/src/renderer/src/pages/Record/YearlyReport.tsx
+++ b/src/renderer/src/pages/Record/YearlyReport.tsx
@@ -39,6 +39,36 @@ export function YearlyReport(): React.JSX.Element {
       }
     })
   }
+  const handleBarClick = (data: any): void => {
+    type MonthlyChartItem = (typeof monthlyChartData)[number]
+    const { originalMonth } = data.payload as MonthlyChartItem
+    const dateUTC = new Date(Date.UTC(selectedYear, originalMonth, 2, 0, 0, 0, 0)) // to avoid timezone issues
+    const isoDate = dateUTC.toISOString()
+
+    router.navigate({
+      to: '/record',
+      search: {
+        tab: 'monthly',
+        date: isoDate,
+        year: dateUTC.getFullYear().toString()
+      }
+    })
+  }
+  const handleDotClick = (data: any): void => {
+    type MonthlyChartItem = (typeof monthlyDaysChartData)[number]
+    const { originalMonth } = data.payload as MonthlyChartItem
+    const dateUTC = new Date(Date.UTC(selectedYear, originalMonth, 2, 0, 0, 0, 0))
+    const isoDate = dateUTC.toISOString()
+
+    router.navigate({
+      to: '/record',
+      search: {
+        tab: 'monthly',
+        date: isoDate,
+        year: search.year
+      }
+    })
+  }
 
   // const [selectedYear, setSelectedYear] = useState<number>(new Date().getFullYear())
   const yearData = getYearlyPlayData(selectedYear)
@@ -202,7 +232,13 @@ export function YearlyReport(): React.JSX.Element {
                     />
                   )}
                 />
-                <Bar dataKey="playTime" fill="var(--primary)" radius={[4, 4, 0, 0]} />
+                <Bar
+                  dataKey="playTime"
+                  fill="var(--primary)"
+                  onClick={handleBarClick}
+                  cursor="pointer"
+                  radius={[4, 4, 0, 0]}
+                />
               </BarChart>
             </ChartContainer>
           </CardContent>
@@ -233,7 +269,13 @@ export function YearlyReport(): React.JSX.Element {
                   dataKey="playDays"
                   stroke="var(--primary)"
                   strokeWidth={2}
-                  dot={false}
+                  dot={{ r: 0 }}
+                  activeDot={{
+                    r: 4,
+                    fill: 'var(--primary)',
+                    cursor: 'pointer',
+                    onClick: (_e, payload) => handleDotClick(payload)
+                  }}
                 />
               </LineChart>
             </ChartContainer>

--- a/src/renderer/src/pages/Record/YearlyReport.tsx
+++ b/src/renderer/src/pages/Record/YearlyReport.tsx
@@ -1,32 +1,46 @@
-import { useState } from 'react'
+import { useRouter, useSearch } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card'
-import { Button } from '~/components/ui/button'
-import { ChevronLeft, ChevronRight, Clock, CalendarIcon, Trophy } from 'lucide-react'
+import { CalendarIcon, ChevronLeft, ChevronRight, Clock, Trophy } from 'lucide-react'
 import {
   Bar,
   BarChart,
   CartesianGrid,
-  XAxis,
-  YAxis,
+  Cell,
   Line,
   LineChart,
-  PieChart,
   Pie,
-  Cell
+  PieChart,
+  XAxis,
+  YAxis
 } from 'recharts'
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from '~/components/ui/chart'
 import type { ValueType } from 'recharts/types/component/DefaultTooltipContent'
+import { Button } from '~/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '~/components/ui/card'
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from '~/components/ui/chart'
 
-import { StatCard } from './StatCard'
-import { GameRankingItem } from './GameRankingItem'
 import { getYearlyPlayData } from '~/stores/game/recordUtils'
+import { GameRankingItem } from './GameRankingItem'
+import { StatCard } from './StatCard'
 
 export function YearlyReport(): React.JSX.Element {
   const { t } = useTranslation('record')
 
-  const [selectedYear, setSelectedYear] = useState<number>(new Date().getFullYear())
+  const router = useRouter()
+  const search = useSearch({ from: '/record' })
+  const selectedYear = Number(search.year)
+
+  const setSelectedYear = (newYear: number): void => {
+    router.navigate({
+      to: '/record',
+      search: {
+        ...search,
+        year: newYear.toString()
+      }
+    })
+  }
+
+  // const [selectedYear, setSelectedYear] = useState<number>(new Date().getFullYear())
   const yearData = getYearlyPlayData(selectedYear)
 
   const goToPreviousYear = (): void => setSelectedYear(selectedYear - 1)

--- a/src/renderer/src/pages/Record/main.tsx
+++ b/src/renderer/src/pages/Record/main.tsx
@@ -1,28 +1,36 @@
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import { ScrollArea } from '~/components/ui/scroll-area'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import { cn } from '~/utils'
 
-import { RecordOverview } from './RecordOverview'
-import { WeeklyReport } from './WeeklyReport'
-import { MonthlyReport } from './MonthlyReport'
-import { YearlyReport } from './YearlyReport'
-import { ScoreReport } from './ScoreReport'
+import { useRouter, useSearch } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
+import { MonthlyReport } from './MonthlyReport'
+import { RecordOverview } from './RecordOverview'
+import { ScoreReport } from './ScoreReport'
+import { WeeklyReport } from './WeeklyReport'
+import { YearlyReport } from './YearlyReport'
 
 export function Record({ className }: { className?: string }): React.JSX.Element {
   const { t } = useTranslation('record')
+  const router = useRouter()
+  const search = useSearch({ from: '/record' })
+
+  const handleTabChange = (value: string): void => {
+    router.navigate({ to: '/record', search: { ...search, tab: value } })
+  }
+
   return (
     <div className={cn('w-full h-full bg-transparent', className)}>
       <ScrollArea className={cn('w-full h-full')}>
         <div className={cn('flex flex-col gap-6 pt-[34px] px-6 pb-6')}>
           <div className={cn('text-2xl font-bold')}>{t('title')}</div>
 
-          <Tabs defaultValue="overview" className="w-full">
+          <Tabs value={search.tab} onValueChange={handleTabChange} className="w-full">
             <TabsList className="mb-4">
               <TabsTrigger value="overview">{t('tabs.overview')}</TabsTrigger>
-              <TabsTrigger value="weekly">{t('tabs.weekly')}</TabsTrigger>
-              <TabsTrigger value="monthly">{t('tabs.monthly')}</TabsTrigger>
               <TabsTrigger value="yearly">{t('tabs.yearly')}</TabsTrigger>
+              <TabsTrigger value="monthly">{t('tabs.monthly')}</TabsTrigger>
+              <TabsTrigger value="weekly">{t('tabs.weekly')}</TabsTrigger>
               <TabsTrigger value="scores">{t('tabs.score')}</TabsTrigger>
             </TabsList>
 
@@ -30,16 +38,16 @@ export function Record({ className }: { className?: string }): React.JSX.Element
               <RecordOverview />
             </TabsContent>
 
-            <TabsContent value="weekly">
-              <WeeklyReport />
+            <TabsContent value="yearly">
+              <YearlyReport />
             </TabsContent>
 
             <TabsContent value="monthly">
               <MonthlyReport />
             </TabsContent>
 
-            <TabsContent value="yearly">
-              <YearlyReport />
+            <TabsContent value="weekly">
+              <WeeklyReport />
             </TabsContent>
 
             <TabsContent value="scores">


### PR DESCRIPTION
**重构了 Record 页结构**：
- 将 Tab 状态与当前查询日期状态提升到路由查询参数中，统一通过 URL 控制页面状态，以实现记录页内部的前进后退导航与各报告的查询值共享
- 调整年报 / 月报 / 周报 Tab 的排列顺序，以提升切换不同报告项时的体验
- 月报图表由原先的周数据改为展示每日数据

**新增了 Record 页内部的快捷跳转功能**：
- 点击年报图表项 → 跳转到对应月报
- 点击月报图表项 → 跳转到对应周报
- 点击游戏时长图表项 → 跳转到对应周报

**其他**：
类似于对记录页的路由修改，将设置页的 Tab 状态提升到路由查询参数，确保返回页面时能够恢复上次的 Tab 选择（Fixes #333 ）