### PR TITLE
feat: add game path display and improve UX in failed folders dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 out
+.idea
 .DS_Store
 .eslintcache
 *.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vnite",
-  "version": "4.2.1",
+  "version": "4.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vnite",
-      "version": "4.2.1",
+      "version": "4.3.1",
       "hasInstallScript": true,
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.4",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -256,7 +256,11 @@ app.whenReady().then(async () => {
 
   baseDBManager.initAllDatabases()
 
-  AuthManager.init()
+  try {
+    AuthManager.init()
+  } catch (error) {
+    log.error('[Account] Failed to initialize AuthManager:', error)
+  }
 
   try {
     AuthManager.updateUserInfo()

--- a/src/renderer/src/components/GameSearch/GameSearch.tsx
+++ b/src/renderer/src/components/GameSearch/GameSearch.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { ipcManager } from '~/app/ipc'
+import { Button } from '~/components/ui/button'
+import { Input } from '~/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
+import { cn } from '~/utils'
+import { GameList } from '@appTypes/utils'
+
+interface GameSearchProps {
+  className?: string
+  dataSource: string
+  defaultName?: string
+  onPick?: (gameId: string, game: GameList[number]) => void
+}
+
+export function GameSearch({ className, dataSource, defaultName, onPick }: GameSearchProps): React.JSX.Element {
+  const { t } = useTranslation('adder')
+  const [name, setName] = useState<string>(defaultName || '')
+  const [results, setResults] = useState<GameList>([])
+  const [selectedId, setSelectedId] = useState<string>('')
+  const [isSearching, setIsSearching] = useState<boolean>(false)
+
+  async function handleSearch(): Promise<void> {
+    if (!name) {
+      toast.warning(t('gameAdder.search.notifications.enterName'))
+      return
+    }
+    if (isSearching) return
+    setIsSearching(true)
+    try {
+      await toast.promise(
+        (async () => {
+          const list = await ipcManager.invoke('scraper:search-games', dataSource, name)
+          setResults(list)
+          if (list.length === 0) {
+            throw new Error(t('gameAdder.search.notifications.notFound'))
+          }
+          setSelectedId(list[0].id)
+          onPick?.(list[0].id, list[0])
+          return list
+        })(),
+        {
+          loading: t('gameAdder.search.notifications.searching'),
+          success: (data: GameList) => t('gameAdder.search.notifications.found', { count: data.length }),
+          error: (err) => t('gameAdder.search.notifications.searchError', { message: err.message })
+        }
+      )
+    } finally {
+      setIsSearching(false)
+    }
+  }
+
+  return (
+    <>
+      <div className={cn('select-none whitespace-nowrap')}>{t('gameAdder.search.gameName')}</div>
+      <div className={cn('flex gap-2', className)}>
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={t('gameAdder.search.gameNamePlaceholder')}
+          className="flex-grow"
+          disabled={isSearching}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') void handleSearch()
+          }}
+        />
+        <Button onClick={() => void handleSearch()} disabled={isSearching}>
+          {isSearching ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              {t('gameAdder.search.notifications.searching')}
+            </>
+          ) : (
+            t('gameAdder.search.searchButton')
+          )}
+        </Button>
+      </div>
+
+      {results.length > 0 && (
+        <>
+          <div />
+          <Select
+            value={selectedId}
+            onValueChange={(val) => {
+              setSelectedId(val)
+              const g = results.find((x) => x.id === val)
+              if (g) onPick?.(val, g)
+            }}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {results.map((g) => (
+                <SelectItem key={g.id} value={g.id}>
+                  {g.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </>
+      )}
+    </>
+  )
+}

--- a/src/renderer/src/pages/GameAdder/Search.tsx
+++ b/src/renderer/src/pages/GameAdder/Search.tsx
@@ -16,10 +16,12 @@ import {
 } from '~/components/ui/select'
 import { cn } from '~/utils'
 import { GameList, useGameAdderStore } from './store'
+import { useGameLocalState } from '~/hooks'
 
 export function Search({ className }: { className?: string }): React.JSX.Element {
   const { t } = useTranslation('adder')
   const {
+    dbId,
     dataSource,
     setDataSource,
     name,
@@ -34,6 +36,21 @@ export function Search({ className }: { className?: string }): React.JSX.Element
     setCurrentPage,
     handleClose
   } = useGameAdderStore()
+
+  const PathRowWithDb = ({ gameId }: { gameId: string }): React.JSX.Element | null => {
+    const [dbGamePath] = useGameLocalState(gameId, 'path.gamePath')
+    const [markPath] = useGameLocalState(gameId, 'utils.markPath')
+    if (!gameId) return null
+    const displayPath = dbGamePath || markPath || ''
+    return (
+      <>
+        <div className={cn('whitespace-nowrap select-none')}>{t('gameAdder.search.gamePath')}</div>
+        <div className={cn('text-xs text-muted-foreground break-all select-text')}>
+          {displayPath || '-'}
+        </div>
+      </>
+    )
+  }
 
   const [availableDataSources, setAvailableDataSources] = React.useState<
     { id: string; name: string; capabilities: ScraperCapabilities[] }[]
@@ -161,6 +178,17 @@ export function Search({ className }: { className?: string }): React.JSX.Element
   return (
     <div className={cn('w-[500px] h-auto', className)}>
       <div className={cn('grid grid-cols-[auto_1fr] gap-x-5 gap-y-2 text-sm items-center')}>
+        {dbId ? (
+          <PathRowWithDb gameId={dbId} />
+        ) : (
+          <>
+            <div className={cn('whitespace-nowrap select-none')}>{t('gameAdder.search.gamePath')}</div>
+            <div className={cn('text-xs text-muted-foreground break-all select-text')}>
+              {gamePath || dirPath || '-'}
+            </div>
+          </>
+        )}
+
         {/* Data source selection */}
         <div className={cn('whitespace-nowrap select-none')}>
           {t('gameAdder.search.dataSource')}

--- a/src/renderer/src/pages/GameScannerManager/FailedFoldersDialog.tsx
+++ b/src/renderer/src/pages/GameScannerManager/FailedFoldersDialog.tsx
@@ -30,6 +30,7 @@ import { ScraperCapabilities } from '@appTypes/utils'
 import { ipcManager } from '~/app/ipc'
 import { useConfigLocalState } from '~/hooks'
 import { toast } from 'sonner'
+import { GameSearch } from '~/components/GameSearch/GameSearch'
 
 interface FailedFoldersDialogProps {
   isOpen: boolean
@@ -37,7 +38,7 @@ interface FailedFoldersDialogProps {
 }
 
 export const FailedFoldersDialog: React.FC<FailedFoldersDialogProps> = ({ isOpen, onClose }) => {
-  const { t } = useTranslation('scanner')
+  const { t } = useTranslation(['scanner', 'adder'])
 
   const { scanProgress, fixFailedFolder, ignoreFailedFolder } = useGameScannerStore()
   const [scannerConfig, setScannerConfig] = useConfigLocalState('game.scanner')
@@ -163,6 +164,14 @@ export const FailedFoldersDialog: React.FC<FailedFoldersDialogProps> = ({ isOpen
               </div>
 
               <div className="grid grid-cols-[auto_1fr] gap-y-4 gap-x-4 items-center">
+                {/* Full folder path */}
+                <div className="select-none whitespace-nowrap">
+                  {t('failedFolders.table.location')}
+                </div>
+                <div className="text-xs text-muted-foreground break-all select-text">
+                  {selectedFolder.path}
+                </div>
+
                 <div className="select-none whitespace-nowrap">{t('failedFolders.dataSource')}</div>
                 <Select value={dataSource} onValueChange={setDataSource}>
                   <SelectTrigger className="">
@@ -176,6 +185,13 @@ export const FailedFoldersDialog: React.FC<FailedFoldersDialogProps> = ({ isOpen
                     ))}
                   </SelectContent>
                 </Select>
+
+                {/* Reusable game search component */}
+                <GameSearch
+                  dataSource={dataSource}
+                  defaultName={selectedFolder?.name}
+                  onPick={(id) => setDataSourceId(id)}
+                />
 
                 <div className="select-none whitespace-nowrap">
                   {t('failedFolders.dataSourceId')}


### PR DESCRIPTION
优化：扫描失败时修复弹框中增加了搜索输入框，免去用户手动查找游戏ID的烦恼
优化：扫描失败时修复弹框中增加了游戏完整路径，方便用户查看当前扫描失败的是哪个游戏目录
<img width="1476" height="645" alt="图片" src="https://github.com/user-attachments/assets/7fa4df71-7a62-4886-b602-bef8c855714e" />

优化：游戏列表右键菜单-管理-更新资料数据弹框中也增加完整路径展示，方便搜索
<img width="683" height="285" alt="图片" src="https://github.com/user-attachments/assets/0fe6b200-7f63-40a6-bdda-aa9fa302a602" />
