### PR TITLE
新增游戏媒体管理功能：截图路径管理、大图查看与右键编辑菜单

### DIFF
--- a/src/renderer/locales/en/game.json
+++ b/src/renderer/locales/en/game.json
@@ -434,6 +434,7 @@
           "importFromClipboard": "Import from clipboard",
           "importFromUrl": "Import from URL",
           "searchImage": "Search image",
+          "viewLargeImage": "View large image",
           "cropImage": "Crop image",
           "deleteImage": "Delete image"
         },

--- a/src/renderer/locales/en/game.json
+++ b/src/renderer/locales/en/game.json
@@ -136,6 +136,9 @@
       "start": "Start Game",
       "stop": "Stop Game"
     },
+    "contextMenu": {
+      "editMediaProperties": "Edit Media Properties"
+    },
     "save": {
       "table": {
         "date": "Date",

--- a/src/renderer/locales/zh-CN/game.json
+++ b/src/renderer/locales/zh-CN/game.json
@@ -136,6 +136,9 @@
       "start": "开始游戏",
       "stop": "停止游戏"
     },
+    "contextMenu": {
+      "editMediaProperties": "修改媒体属性"
+    },
     "save": {
       "table": {
         "date": "日期",

--- a/src/renderer/locales/zh-CN/game.json
+++ b/src/renderer/locales/zh-CN/game.json
@@ -434,6 +434,7 @@
           "importFromClipboard": "从剪贴板导入",
           "importFromUrl": "从链接导入",
           "searchImage": "搜索图片",
+          "viewLargeImage": "查看大图",
           "cropImage": "裁剪图片",
           "deleteImage": "删除图片"
         },

--- a/src/renderer/locales/zh-CN/game.json
+++ b/src/renderer/locales/zh-CN/game.json
@@ -289,15 +289,16 @@
       }
     },
     "memory": {
-      "actions": {
-        "add": "添加",
-        "addCover": "添加封面",
-        "changeCover": "更换封面",
-        "adjustCover": "调整封面",
-        "addText": "添加文字",
-        "editText": "修改文字",
-        "delete": "删除"
-      },
+        "actions": {
+          "add": "添加",
+          "addCover": "添加封面",
+          "changeCover": "更换封面",
+          "adjustCover": "调整封面",
+          "addText": "添加文字",
+          "editText": "修改文字",
+          "delete": "删除",
+          "openScreenshotDir": "打开截图目录"
+        },
       "setAs": {
         "title": "设置为",
         "cover": "游戏封面",
@@ -310,22 +311,23 @@
         "toClipboard": "导出至剪切板",
         "saveAs": "另存为"
       },
-      "notifications": {
-        "deleting": "正在删除…",
-        "deleteSuccess": "删除成功",
-        "deleteError": "删除失败: {{error}}",
-        "selectFileError": "选择文件失败: {{error}}",
-        "imageNotFound": "未找到当前图片",
-        "getImageError": "获取当前图片失败: {{error}}",
-        "imageCopied": "图片已成功复制到剪切板",
-        "imageCopyError": "复制图片到剪切板失败: {{error}}",
-        "markdownCopied": "Markdown 已复制到剪贴板",
-        "markdownCopyError": "复制到剪贴板失败: {{error}}",
-        "setCoverSuccess": "已成功设置为游戏封面",
-        "setCoverError": "设置为游戏封面失败: {{error}}",
-        "setBackgroundSuccess": "已成功设置为游戏背景",
-        "setBackgroundError": "设置为游戏背景失败: {{error}}"
-      },
+        "notifications": {
+          "deleting": "正在删除…",
+          "deleteSuccess": "删除成功",
+          "deleteError": "删除失败: {{error}}",
+          "selectFileError": "选择文件失败: {{error}}",
+          "imageNotFound": "未找到当前图片",
+          "getImageError": "获取当前图片失败: {{error}}",
+          "imageCopied": "图片已成功复制到剪切板",
+          "imageCopyError": "复制图片到剪切板失败: {{error}}",
+          "markdownCopied": "Markdown 已复制到剪贴板",
+          "markdownCopyError": "复制到剪贴板失败: {{error}}",
+          "setCoverSuccess": "已成功设置为游戏封面",
+          "setCoverError": "设置为游戏封面失败: {{error}}",
+          "setBackgroundSuccess": "已成功设置为游戏背景",
+          "setBackgroundError": "设置为游戏背景失败: {{error}}",
+          "screenshotPathNotSet": "未设置截图路径"
+        },
       "dialog": {
         "markdownHint": "支持 Markdown 语法"
       }
@@ -405,6 +407,7 @@
         "title": "游戏与存档",
         "gamePath": "游戏路径",
         "savePath": "存档路径",
+        "screenshotPath": "截图路径",
         "addFolder": "添加文件夹",
         "addFile": "添加文件",
         "maxBackups": "最大存档备份数量",

--- a/src/renderer/src/components/Game/Config/Properties/Media/ImageViewerDialog.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Media/ImageViewerDialog.tsx
@@ -1,0 +1,239 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '~/components/ui/dialog'
+import { Button } from '~/components/ui/button'
+import { cn } from '~/utils'
+
+interface ImageViewerDialogProps {
+  isOpen: boolean
+  imagePath: string | null
+  onClose: () => void
+}
+
+export function ImageViewerDialog({
+  isOpen,
+  imagePath,
+  onClose
+}: ImageViewerDialogProps): React.JSX.Element | null {
+  const { t } = useTranslation('game')
+  const containerRef = useRef<HTMLDivElement>(null)
+  const imgRef = useRef<HTMLImageElement>(null)
+
+  const [scale, setScale] = useState(1)
+  const [translate, setTranslate] = useState({ x: 0, y: 0 })
+  const [isPanning, setIsPanning] = useState(false)
+  const panStart = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+  const lastTranslate = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+  const [naturalSize, setNaturalSize] = useState<{ width: number; height: number }>({
+    width: 0,
+    height: 0
+  })
+
+  useEffect(() => {
+    if (!isOpen) return
+    // Reset state on open
+    setScale(1)
+    setTranslate({ x: 0, y: 0 })
+    lastTranslate.current = { x: 0, y: 0 }
+  }, [isOpen])
+
+  const handleWheel = useCallback(
+    (e: React.WheelEvent) => {
+      e.preventDefault()
+      const delta = e.deltaY
+      const zoomIntensity = 0.1
+      const newScale = Math.max(
+        0.1,
+        Math.min(10, scale * (delta > 0 ? 1 - zoomIntensity : 1 + zoomIntensity))
+      )
+
+      // Zoom to cursor position
+      const rect = containerRef.current?.getBoundingClientRect()
+      if (rect) {
+        const cx = e.clientX - rect.left - rect.width / 2 - translate.x
+        const cy = e.clientY - rect.top - rect.height / 2 - translate.y
+        const ratio = newScale / scale
+        setTranslate({ x: translate.x - cx * (ratio - 1), y: translate.y - cy * (ratio - 1) })
+      }
+
+      setScale(newScale)
+    },
+    [scale, translate]
+  )
+
+  const onMouseDown = (e: React.MouseEvent): void => {
+    e.preventDefault()
+    setIsPanning(true)
+    panStart.current = { x: e.clientX, y: e.clientY }
+    lastTranslate.current = { ...translate }
+  }
+
+  const onMouseMove = (e: React.MouseEvent): void => {
+    if (!isPanning) return
+    const dx = e.clientX - panStart.current.x
+    const dy = e.clientY - panStart.current.y
+    setTranslate({ x: lastTranslate.current.x + dx, y: lastTranslate.current.y + dy })
+  }
+
+  const onMouseUp = (): void => {
+    setIsPanning(false)
+  }
+
+  const getFitScale = (): number => {
+    const container = containerRef.current
+    const img = imgRef.current
+    if (!container || !img) return 1
+
+    const cw = container.clientWidth
+    const ch = container.clientHeight
+    const iw = img.naturalWidth
+    const ih = img.naturalHeight
+    return Math.min(cw / iw, ch / ih)
+  }
+
+  const fitToScreen = (): void => {
+    const scaleFit = getFitScale() as number
+    if (!scaleFit) return
+    setScale(scaleFit)
+    setTranslate({ x: 0, y: 0 })
+    lastTranslate.current = { x: 0, y: 0 }
+  }
+
+  const reset = (): void => {
+    setScale(1)
+    setTranslate({ x: 0, y: 0 })
+    lastTranslate.current = { x: 0, y: 0 }
+  }
+
+  const zoomIn = (): void => setScale((s) => Math.min(10, s * 1.2))
+  const zoomOut = (): void => setScale((s) => Math.max(0.1, s / 1.2))
+
+  const title = useMemo(() => t('detail.properties.media.actions.viewLargeImage'), [t])
+
+  // Handle image load to capture natural size
+  const onImageLoad = (): void => {
+    if (!imgRef.current) return
+    setNaturalSize({ width: imgRef.current.naturalWidth, height: imgRef.current.naturalHeight })
+  }
+
+  // Keyboard shortcuts: + to zoom in, - to zoom out, 0 to reset, f to fit
+  useEffect(() => {
+    if (!isOpen) return
+    const handler = (e: KeyboardEvent): void => {
+      const key = e.key.toLowerCase()
+      if (
+        ['+', '-', '=', '0', 'f', 'arrowup', 'arrowdown', 'arrowleft', 'arrowright'].includes(key)
+      ) {
+        e.preventDefault()
+      }
+      if (key === '+' || key === '=') {
+        setScale((s) => Math.min(10, s * 1.2))
+      } else if (key === '-') {
+        setScale((s) => Math.max(0.1, s / 1.2))
+      } else if (key === '0') {
+        reset()
+      } else if (key === 'f') {
+        fitToScreen()
+      } else if (key === 'arrowup') {
+        setTranslate((tr) => ({ ...tr, y: tr.y + 50 }))
+      } else if (key === 'arrowdown') {
+        setTranslate((tr) => ({ ...tr, y: tr.y - 50 }))
+      } else if (key === 'arrowleft') {
+        setTranslate((tr) => ({ ...tr, x: tr.x + 50 }))
+      } else if (key === 'arrowright') {
+        setTranslate((tr) => ({ ...tr, x: tr.x - 50 }))
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [isOpen])
+
+  // Double click: toggle between 100% and fit-to-screen
+  const onDoubleClick = (): void => {
+    const fit = getFitScale()
+    if (!fit) return
+    const near1 = Math.abs(scale - 1) < 0.02
+    if (near1) {
+      // Switch to fit-to-screen
+      setScale(fit)
+    } else {
+      // Switch to 100%
+      setScale(1)
+    }
+    setTranslate({ x: 0, y: 0 })
+    lastTranslate.current = { x: 0, y: 0 }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent
+        className={cn('w-[80vw] h-[80vh] max-w-none p-0 overflow-hidden flex flex-col gap-0')}
+      >
+        <DialogHeader className={cn('px-4 pt-4 pb-2')}>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <div
+          className={cn('px-4 pb-4 flex items-center gap-3 justify-between')}
+          onMouseLeave={onMouseUp}
+        >
+          <div className={cn('flex items-center gap-2')}>
+            <Button size="sm" variant="outline" onClick={zoomOut}>
+              <span className={cn('icon-[mdi--magnify-minus-outline] w-4 h-4')}></span>
+            </Button>
+            <Button size="sm" variant="outline" onClick={zoomIn}>
+              <span className={cn('icon-[mdi--magnify-plus-outline] w-4 h-4')}></span>
+            </Button>
+            <Button size="sm" variant="outline" onClick={fitToScreen}>
+              <span className={cn('icon-[mdi--fit-to-screen-outline] w-4 h-4')}></span>
+            </Button>
+            <Button size="sm" variant="outline" onClick={reset}>
+              <span className={cn('icon-[mdi--refresh] w-4 h-4')}></span>
+            </Button>
+          </div>
+          <div
+            className={cn('text-xs text-muted-foreground shrink-0')}
+            title={`${naturalSize.width}×${naturalSize.height} px`}
+          >
+            {naturalSize.width > 0 && naturalSize.height > 0
+              ? `${naturalSize.width}×${naturalSize.height} · ${Math.round(scale * 100)}%`
+              : `${Math.round(scale * 100)}%`}
+          </div>
+        </div>
+        <div
+          ref={containerRef}
+          className={cn(
+            'flex-1 bg-background/50 overflow-hidden relative cursor-grab active:cursor-grabbing'
+          )}
+          onWheel={handleWheel}
+          onMouseDown={onMouseDown}
+          onMouseMove={onMouseMove}
+          onMouseUp={onMouseUp}
+          onDoubleClick={onDoubleClick}
+        >
+          {imagePath ? (
+            <div className={cn('absolute inset-0 flex items-center justify-center')}>
+              <img
+                ref={imgRef}
+                src={`file://${imagePath}`}
+                className={cn('select-none pointer-events-none')}
+                style={{
+                  transform: `translate(${translate.x}px, ${translate.y}px) scale(${scale})`,
+                  transformOrigin: 'center center',
+                  maxWidth: 'none',
+                  maxHeight: 'none'
+                }}
+                onLoad={onImageLoad}
+              />
+            </div>
+          ) : (
+            <div
+              className={cn('w-full h-full flex items-center justify-center text-muted-foreground')}
+            >
+              {t('detail.properties.media.empty.images')}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/Game/Config/Properties/Media/main.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Media/main.tsx
@@ -12,6 +12,7 @@ import { cn } from '~/utils'
 import { CropDialog } from './CropDialog'
 import { SearchMediaDialog } from './SearchMediaDialog'
 import { UrlDialog } from './UrlDialog'
+import { ImageViewerDialog } from './ImageViewerDialog'
 
 export function Media({ gameId }: { gameId: string }): React.JSX.Element {
   const { t } = useTranslation('game')
@@ -40,6 +41,9 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
   const [searchType, setSearchType] = useState<'cover' | 'background' | 'icon' | 'logo'>('cover')
 
   const [originalName] = useGameState(gameId, 'metadata.originalName')
+
+  const [isImageViewerOpen, setIsImageViewerOpen] = useState(false)
+  const [imageViewerPath, setImageViewerPath] = useState<string | null>(null)
 
   async function handleFileSelect(type: 'cover' | 'background' | 'icon' | 'logo'): Promise<void> {
     try {
@@ -99,6 +103,22 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
         imagePath: currentPath,
         isResizing: true
       })
+    } catch (error) {
+      toast.error(t('detail.properties.media.notifications.getImageError', { error }))
+    }
+  }
+
+  async function handleViewLargeImage(
+    type: 'cover' | 'background' | 'icon' | 'logo'
+  ): Promise<void> {
+    try {
+      const currentPath = await ipcManager.invoke('game:get-media-path', gameId, type)
+      if (!currentPath) {
+        toast.error(t('detail.properties.media.notifications.imageNotFound'))
+        return
+      }
+      setImageViewerPath(currentPath)
+      setIsImageViewerOpen(true)
     } catch (error) {
       toast.error(t('detail.properties.media.notifications.getImageError', { error }))
     }
@@ -253,6 +273,21 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
       <Tooltip>
         <TooltipTrigger>
           <Button
+            onClick={() => handleViewLargeImage(type)}
+            variant={'outline'}
+            size={'icon'}
+            className={cn('w-7 h-7')}
+          >
+            <span className={cn('icon-[mdi--magnify-plus-cursor] w-4 h-4')}></span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {t('detail.properties.media.actions.viewLargeImage')}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger>
+          <Button
             onClick={() => handleResize(type)}
             variant={'outline'}
             size={'icon'}
@@ -346,6 +381,11 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
             isResizing: false
           })
         }}
+      />
+      <ImageViewerDialog
+        isOpen={isImageViewerOpen}
+        imagePath={imageViewerPath}
+        onClose={() => setIsImageViewerOpen(false)}
       />
     </div>
   )

--- a/src/renderer/src/components/Game/Config/Properties/Path/main.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Path/main.tsx
@@ -36,6 +36,8 @@ export function Path({ gameId }: { gameId: string }): React.JSX.Element {
   const [markerPath] = useGameLocalState(gameId, 'utils.markPath')
   const [maxSaveBackups, setMaxSaveBackups] = useGameState(gameId, 'save.maxBackups')
   const [savePathSize, setSavePathSize] = useState(0)
+  const [screenshotPath, setScreenshotPath, saveScreenshotPath, setScreenshotPathAndSave] =
+    useGameLocalState(gameId, 'path.screenshotPath', true)
 
   useEffect(() => {
     if ((savePaths.length === 1 && savePaths[0] === '') || savePaths.length === 0 || !savePaths) {
@@ -47,6 +49,19 @@ export function Path({ gameId }: { gameId: string }): React.JSX.Element {
       .then((size: number) => setSavePathSize(size))
       .catch(() => setSavePathSize(NaN))
   }, [savePaths])
+
+  async function selectScreenshotFolderPath(): Promise<void> {
+    const folderPath = await ipcManager.invoke(
+      'system:select-path-dialog',
+      ['openDirectory'],
+      undefined,
+      gamePath || markerPath
+    )
+    if (!folderPath) {
+      return
+    }
+    await setScreenshotPathAndSave(folderPath)
+  }
 
   function formatSize(bytes: number): string {
     if (savePathSize === -1) return ''
@@ -144,6 +159,22 @@ export function Path({ gameId }: { gameId: string }): React.JSX.Element {
               />
               <Button variant={'outline'} size={'icon'} onClick={selectGamePath}>
                 <span className={cn('icon-[mdi--file-outline] w-5 h-5')}></span>
+              </Button>
+            </div>
+
+            {/* Screenshot Path */}
+            <div className={cn('whitespace-nowrap select-none self-center')}>
+              {t('detail.properties.path.screenshotPath')}
+            </div>
+            <div className={cn('flex flex-row gap-3 items-center')}>
+              <Input
+                className={cn('flex-1')}
+                value={screenshotPath || ''}
+                onChange={(e) => setScreenshotPath(e.target.value)}
+                onBlur={saveScreenshotPath}
+              />
+              <Button variant={'outline'} size={'icon'} onClick={selectScreenshotFolderPath}>
+                <span className={cn('icon-[mdi--folder-outline] w-5 h-5')}></span>
               </Button>
             </div>
 

--- a/src/renderer/src/components/Game/Config/Properties/main.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/main.tsx
@@ -11,11 +11,13 @@ import { useTranslation } from 'react-i18next'
 export function GamePropertiesDialog({
   gameId,
   isOpen,
-  setIsOpen
+  setIsOpen,
+  defaultTab
 }: {
   gameId: string
   isOpen: boolean
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>
+  defaultTab?: 'launcher' | 'path' | 'media'
 }): React.JSX.Element {
   const { t } = useTranslation('game')
   const [gameName] = useGameState(gameId, 'metadata.name')
@@ -27,7 +29,7 @@ export function GamePropertiesDialog({
           <DialogTitle>{`${gameName} - ${t('detail.properties.title')}`}</DialogTitle>
         </DialogHeader>
 
-        <Tabs defaultValue="launcher" className="flex-1 flex flex-col h-full">
+        <Tabs defaultValue={defaultTab ?? 'launcher'} className="flex-1 flex flex-col h-full">
           <TabsList className="">
             <TabsTrigger value="launcher">{t('detail.properties.tabs.launcher')}</TabsTrigger>
             <TabsTrigger value="path">{t('detail.properties.tabs.path')}</TabsTrigger>

--- a/src/renderer/src/components/Game/Header.tsx
+++ b/src/renderer/src/components/Game/Header.tsx
@@ -19,6 +19,9 @@ import { StartGame } from './StartGame'
 import { StopGame } from './StopGame'
 import { useGameDetailStore } from './store'
 import { GamePropertiesDialog } from './Config/Properties'
+import { ImageViewerDialog } from './Config/Properties/Media/ImageViewerDialog'
+import { ipcManager } from '~/app/ipc'
+import { toast } from 'sonner'
 
 export function Header({
   gameId,
@@ -47,6 +50,23 @@ export function Header({
 
   const [isPropertiesDialogOpen, setIsPropertiesDialogOpen] = React.useState(false)
   const { t } = useTranslation('game')
+
+  const [isImageViewerOpen, setIsImageViewerOpen] = React.useState(false)
+  const [imageViewerPath, setImageViewerPath] = React.useState<string | null>(null)
+
+  async function openLargeCover(): Promise<void> {
+    try {
+      const currentPath = await ipcManager.invoke('game:get-media-path', gameId, 'cover')
+      if (!currentPath) {
+        toast.error(t('detail.properties.media.notifications.imageNotFound'))
+        return
+      }
+      setImageViewerPath(currentPath)
+      setIsImageViewerOpen(true)
+    } catch (error) {
+      toast.error(t('detail.properties.media.notifications.getImageError', { error }))
+    }
+  }
 
   return (
     <>
@@ -129,6 +149,13 @@ export function Header({
               <ContextMenuItem onSelect={() => setIsPropertiesDialogOpen(true)}>
                 {t('detail.contextMenu.editMediaProperties')}
               </ContextMenuItem>
+              <ContextMenuItem
+                onSelect={() => {
+                  void openLargeCover()
+                }}
+              >
+                {t('detail.properties.media.actions.viewLargeImage')}
+              </ContextMenuItem>
             </ContextMenuContent>
           </ContextMenu>
         </div>
@@ -150,6 +177,13 @@ export function Header({
           isOpen={isPropertiesDialogOpen}
           setIsOpen={setIsPropertiesDialogOpen}
           defaultTab={'media'}
+        />
+      )}
+      {isImageViewerOpen && (
+        <ImageViewerDialog
+          isOpen={isImageViewerOpen}
+          imagePath={imageViewerPath}
+          onClose={() => setIsImageViewerOpen(false)}
         />
       )}
     </>

--- a/src/renderer/src/components/Game/Header.tsx
+++ b/src/renderer/src/components/Game/Header.tsx
@@ -1,7 +1,14 @@
 import { NSFWBlurLevel } from '@appTypes/models'
 import React from 'react'
 import { useConfigState, useGameState } from '~/hooks'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '~/components/ui/context-menu'
 import { useRunningGames } from '~/pages/Library/store'
+import { useTranslation } from 'react-i18next'
 import { cn, copyWithToast } from '~/utils'
 import { GameImage } from '../ui/game-image'
 import { Config } from './Config'
@@ -11,6 +18,7 @@ import { Record } from './Overview/Record'
 import { StartGame } from './StartGame'
 import { StopGame } from './StopGame'
 import { useGameDetailStore } from './store'
+import { GamePropertiesDialog } from './Config/Properties'
 
 export function Header({
   gameId,
@@ -36,6 +44,9 @@ export function Header({
   const stringToBase64 = (str: string): string =>
     btoa(String.fromCharCode(...new TextEncoder().encode(str)))
   const obfuscatedName = stringToBase64(name).slice(0, name.length)
+
+  const [isPropertiesDialogOpen, setIsPropertiesDialogOpen] = React.useState(false)
+  const { t } = useTranslation('game')
 
   return (
     <>
@@ -98,19 +109,28 @@ export function Header({
               </div>
             </div>
           </div>
-          {/* Game cover image */}
-          <div className="relative lg:mr-3 pb-1 shrink-0">
-            {showCover && (
-              <GameImage
-                gameId={gameId}
-                key={`${gameId}-poster`}
-                type="cover"
-                blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
-                className={cn('w-auto h-[170px] object-cover rounded-lg shadow-md')}
-                fallback={<div className="h-[170px]" />}
-              />
-            )}
-          </div>
+          {/* Game cover image with context menu */}
+          <ContextMenu>
+            <ContextMenuTrigger asChild>
+              <div className="relative lg:mr-3 pb-1 shrink-0">
+                {showCover && (
+                  <GameImage
+                    gameId={gameId}
+                    key={`${gameId}-poster`}
+                    type="cover"
+                    blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
+                    className={cn('w-auto h-[170px] object-cover rounded-lg shadow-md')}
+                    fallback={<div className="h-[170px]" />}
+                  />
+                )}
+              </div>
+            </ContextMenuTrigger>
+            <ContextMenuContent className={cn('w-40')}>
+              <ContextMenuItem onSelect={() => setIsPropertiesDialogOpen(true)}>
+                {t('detail.contextMenu.editMediaProperties')}
+              </ContextMenuItem>
+            </ContextMenuContent>
+          </ContextMenu>
         </div>
         {/* Game record section */}
         <div className="pt-6">
@@ -123,6 +143,14 @@ export function Header({
       )}
       {isScoreEditorDialogOpen && (
         <ScoreEditorDialog gameId={gameId} setIsOpen={setIsScoreEditorDialogOpen} />
+      )}
+      {isPropertiesDialogOpen && (
+        <GamePropertiesDialog
+          gameId={gameId}
+          isOpen={isPropertiesDialogOpen}
+          setIsOpen={setIsPropertiesDialogOpen}
+          defaultTab={'media'}
+        />
       )}
     </>
   )

--- a/src/renderer/src/components/Game/HeaderCompact.tsx
+++ b/src/renderer/src/components/Game/HeaderCompact.tsx
@@ -11,6 +11,13 @@ import { StartGame } from './StartGame'
 import { StopGame } from './StopGame'
 import { useGameDetailStore } from './store'
 import { useTranslation } from 'react-i18next'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '~/components/ui/context-menu'
+import { GamePropertiesDialog } from './Config/Properties'
 
 export function HeaderCompact({
   gameId,
@@ -40,22 +47,33 @@ export function HeaderCompact({
     btoa(String.fromCharCode(...new TextEncoder().encode(str)))
   const obfuscatedName = stringToBase64(name).slice(0, name.length)
 
+  const [isPropertiesDialogOpen, setIsPropertiesDialogOpen] = React.useState(false)
+
   return (
     <>
       <div className={cn('flex-col flex gap-5 px-7 py-5 pl-6 pt-6 relative mb-5', className)}>
         <div className="flex flex-row gap-1 h-[200px] justify-between items-start">
           {/* Game cover image */}
           {showCover && (
-            <div className="relative mr-3 pb-1 h-[200px] shrink-0">
-              <GameImage
-                gameId={gameId}
-                key={`${gameId}-poster`}
-                type="cover"
-                blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
-                className={cn('w-auto h-full object-cover rounded-lg shadow-md')}
-                fallback={<div className="h-[170px]" />}
-              />
-            </div>
+            <ContextMenu>
+              <ContextMenuTrigger asChild>
+                <div className="relative mr-3 pb-1 h-[200px] shrink-0">
+                  <GameImage
+                    gameId={gameId}
+                    key={`${gameId}-poster`}
+                    type="cover"
+                    blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
+                    className={cn('w-auto h-full object-cover rounded-lg shadow-md')}
+                    fallback={<div className="h-[170px]" />}
+                  />
+                </div>
+              </ContextMenuTrigger>
+              <ContextMenuContent className={cn('w-40')}>
+                <ContextMenuItem onSelect={() => setIsPropertiesDialogOpen(true)}>
+                  {t('detail.contextMenu.editMediaProperties')}
+                </ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
           )}
 
           {/* Main Content */}
@@ -145,6 +163,14 @@ export function HeaderCompact({
       )}
       {isScoreEditorDialogOpen && (
         <ScoreEditorDialog gameId={gameId} setIsOpen={setIsScoreEditorDialogOpen} />
+      )}
+      {isPropertiesDialogOpen && (
+        <GamePropertiesDialog
+          gameId={gameId}
+          isOpen={isPropertiesDialogOpen}
+          setIsOpen={setIsPropertiesDialogOpen}
+          defaultTab={'media'}
+        />
       )}
     </>
   )

--- a/src/renderer/src/components/Game/Memory/main.tsx
+++ b/src/renderer/src/components/Game/Memory/main.tsx
@@ -1,7 +1,7 @@
 import { cn } from '~/utils'
 import { Button } from '~/components/ui/button'
 import { toast } from 'sonner'
-import { useGameState } from '~/hooks'
+import { useGameLocalState, useGameState } from '~/hooks'
 import { MemoryCard } from './MemoryCard'
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -15,9 +15,18 @@ export function Memory({ gameId }: { gameId: string }): React.JSX.Element {
     true
   )
   const [sortedMemoryIds, setSortedMemoryIds] = useState<string[]>([])
+  const [screenshotPath] = useGameLocalState(gameId, 'path.screenshotPath')
 
   async function addMemory(): Promise<void> {
     await ipcManager.invoke('game:add-memory', gameId)
+  }
+
+  async function openScreenshotDir(): Promise<void> {
+    if (!screenshotPath) {
+      toast.error(t('detail.memory.notifications.screenshotPathNotSet'))
+      return
+    }
+    await ipcManager.invoke('system:open-path-in-explorer', screenshotPath)
   }
 
   useEffect(() => {
@@ -63,9 +72,12 @@ export function Memory({ gameId }: { gameId: string }): React.JSX.Element {
 
   return (
     <div className={cn('w-full h-full min-h-[22vh] flex flex-col pt-2 gap-5')}>
-      <div>
+      <div className={cn('flex items-center gap-3')}>
         <Button variant="default" size={'icon'} onClick={addMemory}>
           <span className={cn('icon-[mdi--add] w-6 h-6')}></span>
+        </Button>
+        <Button variant="secondary" onClick={openScreenshotDir}>
+          {t('detail.memory.actions.openScreenshotDir')}
         </Button>
       </div>
       <div className="grid w-full xl:grid-cols-3 lg:grid-cols-2 gap-x-5 gap-y-5">

--- a/src/renderer/src/components/Game/main.tsx
+++ b/src/renderer/src/components/Game/main.tsx
@@ -7,6 +7,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import { useConfigState, useGameState } from '~/hooks'
 import { cn } from '~/utils'
 import { ScrollArea } from '../ui/scroll-area'
+import { ImageViewerDialog } from './Config/Properties/Media/ImageViewerDialog'
+import { ipcManager } from '~/app/ipc'
+import { toast } from 'sonner'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -180,6 +183,22 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
     pos.x === initialPosition.x && pos.y === initialPosition.y
 
   const [isPropertiesDialogOpen, setIsPropertiesDialogOpen] = useState(false)
+  const [isImageViewerOpen, setIsImageViewerOpen] = useState(false)
+  const [imageViewerPath, setImageViewerPath] = useState<string | null>(null)
+
+  async function openLargeBackground(): Promise<void> {
+    try {
+      const currentPath = await ipcManager.invoke('game:get-media-path', gameId, 'background')
+      if (!currentPath) {
+        toast.error(t('detail.properties.media.notifications.imageNotFound'))
+        return
+      }
+      setImageViewerPath(currentPath)
+      setIsImageViewerOpen(true)
+    } catch (error) {
+      toast.error(t('detail.properties.media.notifications.getImageError', { error }))
+    }
+  }
 
   return (
     <div className={cn('w-full h-full relative overflow-hidden shrink-0')}>
@@ -350,6 +369,13 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
             <ContextMenuItem onSelect={() => setIsPropertiesDialogOpen(true)}>
               修改媒体属性
             </ContextMenuItem>
+            <ContextMenuItem
+              onSelect={() => {
+                void openLargeBackground()
+              }}
+            >
+              {t('detail.properties.media.actions.viewLargeImage')}
+            </ContextMenuItem>
           </ContextMenuContent>
         </ContextMenu>
       </ScrollArea>
@@ -360,6 +386,13 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
           isOpen={isPropertiesDialogOpen}
           setIsOpen={setIsPropertiesDialogOpen}
           defaultTab={'media'}
+        />
+      )}
+      {isImageViewerOpen && (
+        <ImageViewerDialog
+          isOpen={isImageViewerOpen}
+          imagePath={imageViewerPath}
+          onClose={() => setIsImageViewerOpen(false)}
         />
       )}
     </div>

--- a/src/renderer/src/components/Game/main.tsx
+++ b/src/renderer/src/components/Game/main.tsx
@@ -7,6 +7,13 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import { useConfigState, useGameState } from '~/hooks'
 import { cn } from '~/utils'
 import { ScrollArea } from '../ui/scroll-area'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '~/components/ui/context-menu'
+import { GamePropertiesDialog } from './Config/Properties'
 import { Header } from './Header'
 import { HeaderCompact } from './HeaderCompact'
 import { Memory } from './Memory'
@@ -86,7 +93,8 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
   }
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>): void => {
-    e.preventDefault()
+      e.preventDefault()
+    if (!isEditingLogo) return
     if (!logoRef.current) return
     if (e.button === 0) {
       setDragging(true)
@@ -171,6 +179,8 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
   const isInitialPosition = (pos: { x: number; y: number }): boolean =>
     pos.x === initialPosition.x && pos.y === initialPosition.y
 
+  const [isPropertiesDialogOpen, setIsPropertiesDialogOpen] = useState(false)
+
   return (
     <div className={cn('w-full h-full relative overflow-hidden shrink-0')}>
       {/* Logo Editing Control Panel */}
@@ -232,28 +242,37 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
 
       {/* Logo Layer */}
       {showLogo && logoVisible && !hideLogo && (
-        <div
-          ref={logoRef}
-          onMouseDown={handleMouseDown}
-          onWheel={handleWheel}
-          style={{
-            transform: `scale(${logoSize / 100})`,
-            left: `${headerLayout === 'compact' && isInitialPosition(localLogoPosition) ? initialPositionInCompact.x : localLogoPosition.x}vw`,
-            top: `${headerLayout === 'compact' && isInitialPosition(localLogoPosition) ? initialPositionInCompact.y : localLogoPosition.y}vh`,
-            cursor: dragging ? 'grabbing' : 'grab',
-            transformOrigin: 'center center',
-            zIndex: isEditingLogo ? 30 : 10 // Increase z-index in editing mode
-          }}
-          className={cn('absolute', 'will-change-transform')}
-        >
-          <GameImage
-            gameId={gameId}
-            key={`${gameId}-logo`}
-            type="logo"
-            className={cn('w-auto max-h-[15vh] object-contain')}
-            fallback={<div className={cn('')} />}
-          />
-        </div>
+        <ContextMenu>
+          <ContextMenuTrigger asChild>
+            <div
+              ref={logoRef}
+              onMouseDown={handleMouseDown}
+              onWheel={handleWheel}
+              style={{
+                transform: `scale(${logoSize / 100})`,
+                left: `${headerLayout === 'compact' && isInitialPosition(localLogoPosition) ? initialPositionInCompact.x : localLogoPosition.x}vw`,
+                top: `${headerLayout === 'compact' && isInitialPosition(localLogoPosition) ? initialPositionInCompact.y : localLogoPosition.y}vh`,
+                cursor: isEditingLogo ? (dragging ? 'grabbing' : 'grab') : 'default',
+                transformOrigin: 'center center',
+                zIndex: isEditingLogo ? 30 : 10
+              }}
+              className={cn('absolute', 'will-change-transform')}
+            >
+              <GameImage
+                gameId={gameId}
+                key={`${gameId}-logo`}
+                type="logo"
+                className={cn('w-auto max-h-[15vh] object-contain')}
+                fallback={<div className={cn('')} />}
+              />
+            </div>
+          </ContextMenuTrigger>
+          <ContextMenuContent className={cn('w-40')}>
+            <ContextMenuItem onSelect={() => setIsPropertiesDialogOpen(true)}>
+              {t('detail.contextMenu.editMediaProperties')}
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
       )}
 
       {/* Scrollable Content Area */}
@@ -261,58 +280,88 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
         ref={scrollAreaRef}
         className={cn('relative h-full w-full overflow-auto rounded-none')}
       >
-        {/* Content Container */}
-        <div
-          className={cn(
-            'relative z-20 flex flex-col w-full min-h-[100vh]',
-            headerLayout === 'compact' && 'p-4'
-          )}
-        >
-          <div className={`mt-(--content-top-padding)`}>
-            {/* Header Area */}
-            <div ref={headerRef} className="pt-1">
-              {headerLayout === 'compact' ? (
-                <HeaderCompact gameId={gameId} />
-              ) : (
-                <Header gameId={gameId} />
+        {/* Content Container with custom context menu */}
+        <ContextMenu>
+          <ContextMenuTrigger asChild>
+            <div
+              className={cn(
+                'relative z-20 flex flex-col w-full min-h-[100vh]',
+                headerLayout === 'compact' && 'p-4'
               )}
-            </div>
+            >
+              <div
+                className={`mt-(--content-top-padding)`}
+                onContextMenu={(e) => {
+                  // Preserve native context menu inside this area
+                  e.stopPropagation()
+                }}
+              >
+                {/* Header Area */}
+                <div ref={headerRef} className="pt-1">
+                  {headerLayout === 'compact' ? (
+                    <HeaderCompact gameId={gameId} />
+                  ) : (
+                    <Header gameId={gameId} />
+                  )}
+                </div>
 
-            {/* Content Area */}
-            <div className={cn('p-7 pt-4 h-full')}>
-              <Tabs defaultValue="overview" className={cn('w-full')}>
-                <TabsList className={cn('w-full justify-start bg-transparent')} variant="underline">
-                  <TabsTrigger className={cn('w-1/4')} value="overview" variant="underline">
-                    {t('detail.tabs.overview')}
-                  </TabsTrigger>
-                  <TabsTrigger className={cn('w-1/4')} value="record" variant="underline">
-                    {t('detail.tabs.record')}
-                  </TabsTrigger>
-                  <TabsTrigger className={cn('w-1/4')} value="save" variant="underline">
-                    {t('detail.tabs.save')}
-                  </TabsTrigger>
-                  <TabsTrigger className={cn('w-1/4')} value="memory" variant="underline">
-                    {t('detail.tabs.memory')}
-                  </TabsTrigger>
-                </TabsList>
+                {/* Content Area */}
+                <div className={cn('p-7 pt-4 h-full')}>
+                  <Tabs defaultValue="overview" className={cn('w-full')}>
+                    <TabsList
+                      className={cn('w-full justify-start bg-transparent')}
+                      variant="underline"
+                    >
+                      <TabsTrigger className={cn('w-1/4')} value="overview" variant="underline">
+                        {t('detail.tabs.overview')}
+                      </TabsTrigger>
+                      <TabsTrigger className={cn('w-1/4')} value="record" variant="underline">
+                        {t('detail.tabs.record')}
+                      </TabsTrigger>
+                      <TabsTrigger className={cn('w-1/4')} value="save" variant="underline">
+                        {t('detail.tabs.save')}
+                      </TabsTrigger>
+                      <TabsTrigger className={cn('w-1/4')} value="memory" variant="underline">
+                        {t('detail.tabs.memory')}
+                      </TabsTrigger>
+                    </TabsList>
 
-                <TabsContent value="overview">
-                  <Overview gameId={gameId} />
-                </TabsContent>
-                <TabsContent value="record">
-                  <Record gameId={gameId} />
-                </TabsContent>
-                <TabsContent value="save">
-                  <Save gameId={gameId} />
-                </TabsContent>
-                <TabsContent value="memory">
-                  <Memory gameId={gameId} />
-                </TabsContent>
-              </Tabs>
+                    <TabsContent value="overview">
+                      <Overview gameId={gameId} />
+                    </TabsContent>
+                    <TabsContent value="record">
+                      <Record gameId={gameId} />
+                    </TabsContent>
+                    <TabsContent value="save">
+                      <Save gameId={gameId} />
+                    </TabsContent>
+                    <TabsContent value="memory">
+                      <Memory gameId={gameId} />
+                    </TabsContent>
+                  </Tabs>
+                </div>
+              </div>
+              {/* Close content container div */}
             </div>
-          </div>
-        </div>
+          </ContextMenuTrigger>
+
+          {/* Custom context menu for the background area of content container */}
+          <ContextMenuContent className={cn('w-40')}>
+            <ContextMenuItem onSelect={() => setIsPropertiesDialogOpen(true)}>
+              修改媒体属性
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
       </ScrollArea>
+
+      {isPropertiesDialogOpen && (
+        <GamePropertiesDialog
+          gameId={gameId}
+          isOpen={isPropertiesDialogOpen}
+          setIsOpen={setIsPropertiesDialogOpen}
+          defaultTab={'media'}
+        />
+      )}
     </div>
   )
 }

--- a/src/types/models/game.ts
+++ b/src/types/models/game.ts
@@ -93,6 +93,7 @@ export interface gameLocalDoc {
   path: {
     gamePath: string
     savePaths: string[]
+    screenshotPath?: string
   }
   launcher: {
     mode: 'file' | 'url' | 'script'
@@ -126,7 +127,8 @@ export const DEFAULT_GAME_LOCAL_VALUES: Readonly<gameLocalDoc> = {
   _id: '',
   path: {
     gamePath: '',
-    savePaths: []
+    savePaths: [],
+    screenshotPath: ''
   },
   launcher: {
     mode: 'file',


### PR DESCRIPTION
- 支持设置和管理游戏的截图保存路径  
- 在“回忆”界面中添加一键打开截图路径的按钮，方便快速访问截图文件夹
- 在游戏详情页新增 **编辑媒体属性** 和 **查看大图** 右键菜单，便于快速修改媒体信息
- 允许在大图模式下复制或保存图片