### PR TITLE
feat(poster): improve visual feedback of quick-play button

### DIFF
--- a/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
@@ -10,13 +10,13 @@ import { PlayTimeEditorDialog } from '~/components/Game/Config/ManageMenu/PlayTi
 import { GamePropertiesDialog } from '~/components/Game/Config/Properties'
 import { BatchGameNavCM } from '~/components/GameBatchEditor/BatchGameNavCM'
 import { useGameBatchEditorStore } from '~/components/GameBatchEditor/store'
-import { Button } from '~/components/ui/button'
 import { ContextMenu, ContextMenuTrigger } from '~/components/ui/context-menu'
 import { GameImage } from '~/components/ui/game-image'
 import { useConfigState, useGameState } from '~/hooks'
 import { useRunningGames } from '~/pages/Library/store'
 import { useGameRegistry } from '~/stores/game'
-import { cn, navigateToGame, startGame, stopGame } from '~/utils'
+import { cn, navigateToGame } from '~/utils'
+import { PlayButton } from './PlayButton'
 
 export function BigGamePoster({
   gameId,
@@ -167,31 +167,13 @@ export function BigGamePoster({
 
                 {/* Play button */}
                 <div className="absolute inset-0 flex items-center justify-center flex-grow">
-                  {showPlayButtonOnPoster &&
-                    (runningGames.includes(gameId) ? (
-                      <Button
-                        variant="secondary"
-                        className="rounded-full w-[46px] h-[46px] p-0 bg-secondary hover:bg-secondary/90"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          stopGame(gameId)
-                        }}
-                      >
-                        <span className="icon-[mdi--stop] text-secondary-foreground w-7 h-7"></span>
-                      </Button>
-                    ) : (
-                      <Button
-                        variant="default"
-                        className="rounded-full w-[46px] h-[46px] p-0 bg-primary hover:bg-primary/90"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          navigateToGame(navigate, gameId, groupId || 'all')
-                          startGame(gameId)
-                        }}
-                      >
-                        <span className="icon-[mdi--play] text-primary-foreground w-7 h-7"></span>
-                      </Button>
-                    ))}
+                  {showPlayButtonOnPoster && (
+                    <PlayButton
+                      type={runningGames.includes(gameId) ? 'stop' : 'play'}
+                      gameId={gameId}
+                      groupId={groupId}
+                    />
+                  )}
                 </div>
 
                 {/* Game info */}

--- a/src/renderer/src/components/Showcase/posters/GamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/GamePoster.tsx
@@ -11,13 +11,12 @@ import { GamePropertiesDialog } from '~/components/Game/Config/Properties'
 import { BatchGameNavCM } from '~/components/GameBatchEditor/BatchGameNavCM'
 import { useGameBatchEditorStore } from '~/components/GameBatchEditor/store'
 import { useDragContext } from '~/components/Showcase/CollectionGames'
-import { Button } from '~/components/ui/button'
 import { ContextMenu, ContextMenuTrigger } from '~/components/ui/context-menu'
 import { GameImage } from '~/components/ui/game-image'
 import { useConfigState, useGameState } from '~/hooks'
 import { useRunningGames } from '~/pages/Library/store'
 import { useGameCollectionStore, useGameRegistry } from '~/stores/game'
-import { cn, navigateToGame, startGame, stopGame } from '~/utils'
+import { cn, navigateToGame } from '~/utils'
 import {
   attachClosestEdge,
   calPreviewOffset,
@@ -32,6 +31,7 @@ import {
   type Edge,
   type PreviewState
 } from '~/utils/dnd-utills'
+import { PlayButton } from './PlayButton'
 
 function Preview({
   title,
@@ -290,35 +290,13 @@ export function GamePoster({
 
                     {/* Play button */}
                     <div className="absolute inset-0 flex items-center justify-center flex-grow">
-                      {showPlayButtonOnPoster &&
-                        (runningGames.includes(gameId) ? (
-                          <Button
-                            variant="secondary"
-                            className={cn(
-                              'rounded-full w-[46px] h-[46px] p-0 shadow-sm bg-secondary hover:bg-secondary/90'
-                            )}
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              stopGame(gameId)
-                            }}
-                          >
-                            <span className="icon-[mdi--stop] text-secondary-foreground w-7 h-7"></span>
-                          </Button>
-                        ) : (
-                          <Button
-                            variant="default"
-                            className={cn(
-                              'rounded-full w-[46px] h-[46px] p-0 bg-primary hover:bg-primary/90'
-                            )}
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              navigateToGame(navigate, gameId, groupId || 'all')
-                              startGame(gameId)
-                            }}
-                          >
-                            <span className="icon-[mdi--play] text-primary-foreground w-7 h-7"></span>
-                          </Button>
-                        ))}
+                      {showPlayButtonOnPoster && (
+                        <PlayButton
+                          type={runningGames.includes(gameId) ? 'stop' : 'play'}
+                          gameId={gameId}
+                          groupId={groupId}
+                        />
+                      )}
                     </div>
 
                     {/* Game info */}

--- a/src/renderer/src/components/Showcase/posters/PlayButton.tsx
+++ b/src/renderer/src/components/Showcase/posters/PlayButton.tsx
@@ -1,0 +1,75 @@
+import { useNavigate } from '@tanstack/react-router'
+import { VariantProps } from 'class-variance-authority'
+import { Button, buttonVariants } from '~/components/ui/button'
+import { cn, navigateToGame, startGame, stopGame } from '~/utils'
+
+type PlayButtonType = 'play' | 'stop'
+type PlayButtonConfig = {
+  variant: VariantProps<typeof buttonVariants>['variant']
+  buttonClassName: string
+  iconClassName: string
+}
+
+const PLAY_BUTTON_CONFIGS: Record<PlayButtonType, PlayButtonConfig> = {
+  play: {
+    variant: 'default',
+    buttonClassName: 'bg-primary hover:bg-primary/60',
+    iconClassName: 'icon-[mdi--play] text-primary-foreground'
+  },
+  stop: {
+    variant: 'secondary',
+    buttonClassName: 'bg-secondary hover:bg-secondary/60',
+    iconClassName: 'icon-[mdi--stop] text-secondary-foreground'
+  }
+}
+
+export function PlayButton({
+  gameId,
+  groupId,
+  type
+}: {
+  gameId: string
+  groupId?: string
+  type: PlayButtonType
+}): React.JSX.Element {
+  const config = PLAY_BUTTON_CONFIGS[type]
+  const navigate = useNavigate()
+
+  const getHandler = (type: PlayButtonType) => {
+    switch (type) {
+      case 'play':
+        return (e: React.MouseEvent<HTMLButtonElement>) => {
+          e.stopPropagation()
+          navigateToGame(navigate, gameId, groupId || 'all')
+          startGame(gameId)
+        }
+      case 'stop':
+        return (e: React.MouseEvent<HTMLButtonElement>) => {
+          e.stopPropagation()
+          stopGame(gameId)
+        }
+    }
+  }
+
+  return (
+    <div className="relative w-[46px] h-[46px]">
+      <Button
+        variant={config.variant}
+        className={cn(
+          'rounded-full w-full h-full p-0',
+          'peer transition-transform duration-200 ease-in-out hover:scale-150',
+          config.buttonClassName
+        )}
+        onClick={getHandler(type)}
+      />
+      <span
+        className={cn(
+          'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
+          'w-7 h-7 pointer-events-none',
+          'transition-transform duration-200 ease-in-out peer-hover:scale-95',
+          config.iconClassName
+        )}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
加强了主页海报快速游玩按钮的视觉提示，以避免误触。
> 目前按钮在鼠标悬停时不仅有透明度变化，还会伴随尺寸改变。