### PR TITLE
fix(scraper): fix missing fields when scraping DLSite works with “VJ” IDs

### DIFF
--- a/src/main/features/scraper/providers/dlsite/common.ts
+++ b/src/main/features/scraper/providers/dlsite/common.ts
@@ -8,6 +8,14 @@ import i18next from 'i18next'
 
 const ID_REGEX = /(rj|re|vj)\d{4,}/gi
 
+function buildDlsiteWorkUrl(dlsiteId: string, language?: string): string {
+  const localePart = language ? `?locale=${language}` : ''
+  if (dlsiteId.startsWith('VJ')) {
+    return `https://www.dlsite.com/pro/work/=/product_id/${dlsiteId}.html${localePart}`
+  }
+  return `https://www.dlsite.com/maniax/work/=/product_id/${dlsiteId}.html${localePart}`
+}
+
 export async function searchDlsiteGames(gameName: string): Promise<GameList> {
   const findIdInName = await ConfigDBManager.getConfigValue('game.scraper.dlsite.findIdInName')
   if (findIdInName) {
@@ -88,7 +96,7 @@ export async function searchDlsiteGames(gameName: string): Promise<GameList> {
 export async function getDlsiteMetadata(dlsiteId: string): Promise<GameMetadata> {
   // Try to access the work page
   const language = await getLanguage()
-  const url = `https://www.dlsite.com/maniax/work/=/product_id/${dlsiteId}.html?locale=${language}`
+  const url = buildDlsiteWorkUrl(dlsiteId, language)
 
   const response = await net.fetch(url, {
     headers: {
@@ -310,7 +318,7 @@ export async function getDlsiteMetadataByName(gameName: string): Promise<GameMet
 
 export async function getGameBackgrounds(dlsiteId: string): Promise<string[]> {
   try {
-    const url = `https://www.dlsite.com/maniax/work/=/product_id/${dlsiteId}.html`
+    const url = buildDlsiteWorkUrl(dlsiteId)
     const language = await getLanguage()
 
     const response = await net.fetch(url, {
@@ -370,7 +378,7 @@ export async function getGameBackgroundsByName(gameName: string): Promise<string
 
 export async function getGameCover(dlsiteId: string): Promise<string> {
   try {
-    const url = `https://www.dlsite.com/maniax/work/=/product_id/${dlsiteId}.html`
+    const url = buildDlsiteWorkUrl(dlsiteId)
     const language = await getLanguage()
 
     const response = await net.fetch(url, {
@@ -441,7 +449,7 @@ export async function getGameCoverByName(gameName: string): Promise<string> {
 
 export async function checkGameExists(dlsiteId: string): Promise<boolean> {
   try {
-    const url = `https://www.dlsite.com/maniax/work/=/product_id/${dlsiteId}.html`
+    const url = buildDlsiteWorkUrl(dlsiteId)
 
     const response = await net.fetch(url, {
       headers: {


### PR DESCRIPTION
VJ开头编码的DLSite页面地址中间为/pro/work/而非/maniax/work/, 使用/maniax/work/地址访问虽会被重定向到正确的/pro/work/地址页面, 但重定向后会丢失locale参数, 导致获取到的页面语言版本可能与期望的不一致.
语言版本不一致会导致发售日等信息无法获取, 而tag等信息虽能获取但语言不对.

- 本PR增加根据编码前缀判断构建请求URL, 避免被重定向丢失参数
- scraper:dlsite.workType的简繁中文以及scraper:dlsite.releaseDate的简中国际化文本与DLSite页面不一致, 会影响发售日和作品类型的获取, 已在weblate上更正