### PR TITLE
fix(game properties config): ensure data is saved when switching tabs

### DIFF
--- a/src/renderer/src/components/Game/Config/Properties/Launcher/ScriptLauncher.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Launcher/ScriptLauncher.tsx
@@ -1,9 +1,9 @@
-import { cn } from '~/utils'
-import { useGameLocalState } from '~/hooks'
-import { Input } from '~/components/ui/input'
-import { Button } from '~/components/ui/button'
+import React, { useCallback, useImperativeHandle } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ipcManager } from '~/app/ipc'
 import { ArrayTextarea } from '~/components/ui/array-textarea'
-import { Separator } from '~/components/ui/separator'
+import { Button } from '~/components/ui/button'
+import { Input } from '~/components/ui/input'
 import {
   Select,
   SelectContent,
@@ -13,10 +13,18 @@ import {
   SelectTrigger,
   SelectValue
 } from '~/components/ui/select'
-import { useTranslation } from 'react-i18next'
-import { ipcManager } from '~/app/ipc'
+import { Separator } from '~/components/ui/separator'
+import { useGameLocalState } from '~/hooks'
+import { cn } from '~/utils'
 
-export function ScriptLauncher({ gameId }: { gameId: string }): React.JSX.Element {
+export interface ScriptLauncherHandle {
+  save: () => Promise<void>
+}
+
+function ScriptLauncherComponent(
+  { gameId }: { gameId: string },
+  ref: React.Ref<ScriptLauncherHandle>
+): React.JSX.Element {
   const { t } = useTranslation('game')
   const [command, setCommand, saveCommand] = useGameLocalState(
     gameId,
@@ -63,6 +71,12 @@ export function ScriptLauncher({ gameId }: { gameId: string }): React.JSX.Elemen
       ipcManager.send('native-monitor:update-local-game')
     }
   }
+
+  const saveAll = useCallback(async () => {
+    await Promise.all([saveCommand(), saveWorkingDirectory(), saveMonitorPath()])
+    ipcManager.send('native-monitor:update-local-game')
+  }, [saveCommand, saveWorkingDirectory, saveMonitorPath])
+  useImperativeHandle(ref, () => ({ save: saveAll }), [saveAll])
 
   return (
     <>
@@ -137,8 +151,7 @@ export function ScriptLauncher({ gameId }: { gameId: string }): React.JSX.Elemen
           value={monitorPath}
           onChange={(e) => setMonitorPath(e.target.value)}
           onBlur={() => {
-            saveMonitorPath()
-            ipcManager.send('native-monitor:update-local-game')
+            saveMonitorPath().then(() => ipcManager.send('native-monitor:update-local-game'))
           }}
         />
         {['folder', 'file'].includes(monitorMode) && (
@@ -156,3 +169,5 @@ export function ScriptLauncher({ gameId }: { gameId: string }): React.JSX.Elemen
     </>
   )
 }
+
+export const ScriptLauncher = React.forwardRef(ScriptLauncherComponent)

--- a/src/renderer/src/components/Game/Config/Properties/Launcher/UrlLauncher.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Launcher/UrlLauncher.tsx
@@ -1,8 +1,8 @@
-import { cn } from '~/utils'
-import { useGameLocalState } from '~/hooks'
-import { Input } from '~/components/ui/input'
+import React, { useCallback, useImperativeHandle } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ipcManager } from '~/app/ipc'
 import { Button } from '~/components/ui/button'
-import { Separator } from '~/components/ui/separator'
+import { Input } from '~/components/ui/input'
 import {
   Select,
   SelectContent,
@@ -12,10 +12,18 @@ import {
   SelectTrigger,
   SelectValue
 } from '~/components/ui/select'
-import { useTranslation } from 'react-i18next'
-import { ipcManager } from '~/app/ipc'
+import { Separator } from '~/components/ui/separator'
+import { useGameLocalState } from '~/hooks'
+import { cn } from '~/utils'
 
-export function UrlLauncher({ gameId }: { gameId: string }): React.JSX.Element {
+export interface UrlLauncherHandle {
+  save: () => Promise<void>
+}
+
+function UrlLauncherComponent(
+  { gameId }: { gameId: string },
+  ref: React.Ref<UrlLauncherHandle>
+): React.JSX.Element {
   const { t } = useTranslation('game')
   const [url, setUrl, saveUrl] = useGameLocalState(gameId, 'launcher.urlConfig.url', true)
   const [browserPath, setBrowserPath, saveBrowserPath, setBrowserPathAndSave] = useGameLocalState(
@@ -60,6 +68,12 @@ export function UrlLauncher({ gameId }: { gameId: string }): React.JSX.Element {
       ipcManager.send('native-monitor:update-local-game')
     }
   }
+
+  const saveAll = useCallback(async () => {
+    await Promise.all([saveUrl(), saveMonitorPath(), saveBrowserPath()])
+    ipcManager.send('native-monitor:update-local-game')
+  }, [saveUrl, saveMonitorPath, saveBrowserPath])
+  useImperativeHandle(ref, () => ({ save: saveAll }), [saveAll])
 
   return (
     <>
@@ -135,8 +149,7 @@ export function UrlLauncher({ gameId }: { gameId: string }): React.JSX.Element {
           value={monitorPath}
           onChange={(e) => setMonitorPath(e.target.value)}
           onBlur={() => {
-            saveMonitorPath()
-            ipcManager.send('native-monitor:update-local-game')
+            saveMonitorPath().then(() => ipcManager.send('native-monitor:update-local-game'))
           }}
         />
         {['folder', 'file'].includes(monitorMode) && (
@@ -154,3 +167,5 @@ export function UrlLauncher({ gameId }: { gameId: string }): React.JSX.Element {
     </>
   )
 }
+
+export const UrlLauncher = React.forwardRef(UrlLauncherComponent)

--- a/src/renderer/src/components/Game/Config/Properties/main.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/main.tsx
@@ -1,12 +1,13 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '~/components/ui/dialog'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
-import { ScrollArea } from '~/components/ui/scroll-area'
-import { cn } from '~/utils'
-import { Launcher } from './Launcher'
-import { Path } from './Path'
-import { Media } from './Media'
-import { useGameState } from '~/hooks'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '~/components/ui/dialog'
+import { ScrollArea } from '~/components/ui/scroll-area'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
+import { useGameState } from '~/hooks'
+import { cn } from '~/utils'
+import { Launcher, LauncherHandle } from './Launcher'
+import { Media } from './Media'
+import { Path, PathHandle } from './Path'
 
 export function GamePropertiesDialog({
   gameId,
@@ -21,6 +22,21 @@ export function GamePropertiesDialog({
 }): React.JSX.Element {
   const { t } = useTranslation('game')
   const [gameName] = useGameState(gameId, 'metadata.name')
+  const [activeTab, setActiveTab] = useState<'launcher' | 'path' | 'media'>(
+    defaultTab ?? 'launcher'
+  )
+
+  const pathRef = useRef<PathHandle>(null)
+  const launcherRef = useRef<LauncherHandle>(null)
+  async function handleTabChange(newTab: string): Promise<void> {
+    // When directly change tab after edit input, the change may not be saved
+    if (activeTab === 'path') {
+      await pathRef.current?.save()
+    } else if (activeTab === 'launcher') {
+      await launcherRef.current?.save()
+    }
+    setActiveTab(newTab as 'launcher' | 'path' | 'media')
+  }
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -29,7 +45,11 @@ export function GamePropertiesDialog({
           <DialogTitle>{`${gameName} - ${t('detail.properties.title')}`}</DialogTitle>
         </DialogHeader>
 
-        <Tabs defaultValue={defaultTab ?? 'launcher'} className="flex-1 flex flex-col h-full">
+        <Tabs
+          value={activeTab}
+          onValueChange={handleTabChange}
+          className="flex-1 flex flex-col h-full"
+        >
           <TabsList className="">
             <TabsTrigger value="launcher">{t('detail.properties.tabs.launcher')}</TabsTrigger>
             <TabsTrigger value="path">{t('detail.properties.tabs.path')}</TabsTrigger>
@@ -39,11 +59,11 @@ export function GamePropertiesDialog({
           {/* -ml-1 and pl-1 to show the left shadow */}
           <ScrollArea className="h-[calc(95%-60px)] -ml-1">
             <TabsContent value="launcher" className="pr-5 pb-3 pl-1">
-              <Launcher gameId={gameId} />
+              <Launcher gameId={gameId} ref={launcherRef} />
             </TabsContent>
 
             <TabsContent value="path" className="pr-5 pb-3 pl-1">
-              <Path gameId={gameId} />
+              <Path gameId={gameId} ref={pathRef} />
             </TabsContent>
 
             <TabsContent value="media" className="pr-5 pb-3 pl-1">


### PR DESCRIPTION
在游戏的属性设置对话框中有若干 `input`，其依靠 `onBlur` 方法将积累的修改保存到后端。但是如果在修改后，直接点击上方标签页进行切换，该方法不会被触发，从而导致修改丢失。

本提交通过将相关保存函数暴露到上层，在切换标签页前手动调用保存以解决该问题。