### PR TITLE
feat(play-time-editor): add import/export functionality for timer list

### DIFF
--- a/src/renderer/locales/en/game.json
+++ b/src/renderer/locales/en/game.json
@@ -382,10 +382,17 @@
       "ongoing": "In progress",
       "duration": "Duration",
       "minutes": "minutes",
+      "confirmImport": "Are you sure you want to save changes?",
+      "importWarning": "An import operation was detected; original data will be overwritten. Do you want to continue?",
+      "action": {
+        "importFromClipboard": "Import from clipboard",
+        "exportToClipboard": "Export to clipboard"
+      },
       "error": {
         "overlapMessage": "Timers {{first}} and {{second}} overlap!",
         "invalidTime": "Timer {{index}} has invalid start or end time!",
-        "endBeforeStart": "Timer {{index}} ends before it starts!"
+        "endBeforeStart": "Timer {{index}} ends before it starts!",
+        "invalidJson": "Invalid JSON format: {{error}}"
       }
     },
     "timerEditor": {

--- a/src/renderer/locales/ja/game.json
+++ b/src/renderer/locales/ja/game.json
@@ -382,10 +382,17 @@
       "ongoing": "進行中",
       "duration": "時間",
       "minutes": "分",
+      "confirmImport": "変更を保存してもよろしいですか？",
+      "importWarning": "インポート操作が検出されました。元のデータは上書きされます。続行しますか？",
+      "action": {
+        "importFromClipboard": "クリップボードからインポート",
+        "exportToClipboard": "クリップボードにエクスポート"
+      },
       "error": {
         "overlapMessage": "タイマー {{first}} と {{second}} が重複しています！",
-        "invalidTime": "タイマー {{index}} の開始または終了時刻が無効です！",
-        "endBeforeStart": "タイマー {{index}} の終了時刻が開始時刻より前です！"
+        "invalidTime": "タイマー {{index}} の開始または終了時間が無効です！",
+        "endBeforeStart": "タイマー {{index}} の終了時間が開始時間より前です！",
+        "invalidJson": "無効な JSON 形式: {{error}}"
       }
     },
     "timerEditor": {

--- a/src/renderer/locales/zh-CN/game.json
+++ b/src/renderer/locales/zh-CN/game.json
@@ -382,10 +382,17 @@
       "ongoing": "进行中",
       "duration": "时长",
       "minutes": "分钟",
+      "confirmImport": "确定要保存更改吗？",
+      "importWarning": "检测到曾进行导入操作，原始数据将被覆盖。确定要继续保存吗？",
+      "action": {
+        "importFromClipboard": "从剪贴板导入",
+        "exportToClipboard": "导出至剪贴板"
+      },
       "error": {
         "overlapMessage": "计时器 {{first}} 和 {{second}} 重叠！",
         "invalidTime": "计时器 {{index}} 的开始或结束时间无效！",
-        "endBeforeStart": "计时器 {{index}} 的结束时间早于开始时间！"
+        "endBeforeStart": "计时器 {{index}} 的结束时间早于开始时间！",
+        "invalidJson": "无效的 Json 格式: {{error}}"
       }
     },
     "timerEditor": {

--- a/src/renderer/locales/zh-TW/game.json
+++ b/src/renderer/locales/zh-TW/game.json
@@ -382,10 +382,17 @@
       "ongoing": "進行中",
       "duration": "時長",
       "minutes": "分鐘",
+      "confirmImport": "確定要保存更改嗎？",
+      "importWarning": "檢測到曾進行導入操作，原始資料將被覆蓋。確定要繼續保存嗎？",
+      "action": {
+        "importFromClipboard": "從剪貼簿導入",
+        "exportToClipboard": "匯出至剪貼簿"
+      },
       "error": {
         "overlapMessage": "計時器 {{first}} 和 {{second}} 重疊！",
         "invalidTime": "計時器 {{index}} 的開始或結束時間無效！",
-        "endBeforeStart": "計時器 {{index}} 的結束時間早於開始時間！"
+        "endBeforeStart": "計時器 {{index}} 的結束時間早於開始時間！",
+        "invalidJson": "無效的 JSON 格式: {{error}}"
       }
     },
     "timerEditor": {

--- a/src/renderer/src/components/Game/Config/ManageMenu/TimerEditDialog.tsx
+++ b/src/renderer/src/components/Game/Config/ManageMenu/TimerEditDialog.tsx
@@ -1,15 +1,9 @@
-import { Button } from '~/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle
-} from '~/components/ui/dialog'
-import { useState, useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
+import { Button } from '@ui/button'
+import { DateTimeInput } from '@ui/date-input'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@ui/dialog'
 import { format } from 'date-fns'
-import { DateTimeInput } from '~/components/ui/date-input'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 interface TimerEditDialogProps {
   isOpen: boolean
@@ -50,7 +44,7 @@ export function TimerEditDialog({
       // Initialize with current time if adding new timer
       const now = new Date()
       setStartDateTime(format(now, "yyyy-MM-dd'T'HH:mm"))
-      setEndDateTime('')
+      setEndDateTime(format(now, "yyyy-MM-dd'T'HH:mm"))
     }
     setError(null)
   }, [timer, isOpen, isNew])


### PR DESCRIPTION
- 在游玩计时器的编辑窗口中，增加了导入导出功能，目前仅支持剪贴板。
> Resolves #458 
- 在单个游戏的计时器编辑窗口，自动将当前时间填充到终点输入框，以减少操作步骤