### PR TITLE
fix: white screen when restoring minimized mainWindow from tray

### DIFF
--- a/src/main/features/system/ipc.ts
+++ b/src/main/features/system/ipc.ts
@@ -54,11 +54,11 @@ export function setupSystemIPC(): void {
   })
 
   ipcManager.on('window:restore-and-focus', () => {
-    if (mainWindow.isMinimized()) {
-      mainWindow.restore()
-    }
     if (!mainWindow.isVisible()) {
       mainWindow.show()
+    }
+    if (mainWindow.isMinimized()) {
+      mainWindow.restore()
     }
     mainWindow.focus()
   })

--- a/src/main/features/system/services/tray.ts
+++ b/src/main/features/system/services/tray.ts
@@ -1,10 +1,9 @@
-import { app, Tray, Menu, nativeImage, BrowserWindow } from 'electron'
-import { GameDBManager, ConfigDBManager } from '~/core/database'
+import { app, BrowserWindow, Menu, nativeImage, shell, Tray } from 'electron'
+import i18next from 'i18next'
+import { ConfigDBManager, GameDBManager } from '~/core/database'
 import { eventBus } from '~/core/events'
-import { shell } from 'electron'
 import { convertToPng } from '~/utils'
 import icon from '../../../../../resources/icon.ico?asset'
-import i18next from 'i18next'
 
 export interface AppConfig {
   openAtLogin: boolean
@@ -215,11 +214,11 @@ export class TrayManager {
   private showMainWindow(): void {
     if (!this.mainWindow) return
 
-    if (this.mainWindow.isMinimized()) {
-      this.mainWindow.restore()
-    }
     if (!this.mainWindow.isVisible()) {
       this.mainWindow.show()
+    }
+    if (this.mainWindow.isMinimized()) {
+      this.mainWindow.restore()
     }
     this.mainWindow.focus()
   }


### PR DESCRIPTION
当程序在最小化状态下被隐藏到托盘后，从托盘恢复的窗口会显示为白屏。

本提交通过修改恢复过程中`restore()`方法与`show()`方法的调用顺序，使得最小化状态下隐藏到托盘的程序窗口能够被恰当恢复，不过恢复过程会存在一个极短时间的闪烁，应该是重绘所需的时间。