### PR TITLE
fix: high CPU usage when deleting collection

### DIFF
--- a/src/main/core/database/BaseDBManager.ts
+++ b/src/main/core/database/BaseDBManager.ts
@@ -1,14 +1,18 @@
-import PouchDB from 'pouchdb'
-import { SyncOptions, AttachmentReturnType } from './types'
-import { convertBufferToFile, convertFileToBuffer, convertBufferToTempFile } from '~/utils'
-import { getDataPath, setupProxy } from '~/features/system'
 import { getValueByPath, setValueByPath } from '@appUtils'
-import { fileTypeFromBuffer } from 'file-type'
-import upsertPlugin from 'pouchdb-upsert'
 import { net } from 'electron'
 import log from 'electron-log/main'
+import { fileTypeFromBuffer } from 'file-type'
+import PouchDB from 'pouchdb'
+import upsertPlugin from 'pouchdb-upsert'
 import { ipcManager } from '~/core/ipc'
-import { createOfficialRemoteDBWithPermissions } from '~/utils'
+import { getDataPath, setupProxy } from '~/features/system'
+import {
+  convertBufferToFile,
+  convertBufferToTempFile,
+  convertFileToBuffer,
+  createOfficialRemoteDBWithPermissions
+} from '~/utils'
+import { AttachmentReturnType, SyncOptions } from './types'
 
 PouchDB.plugin(upsertPlugin)
 
@@ -71,13 +75,13 @@ export class BaseDBManager {
         return
       }
 
+      if (path === '#all' && value === '#delete') {
+        await this.removeDoc(dbName, docId)
+        return
+      }
+
       await db.upsert(docId, (doc: any) => {
         if (path === '#all') {
-          // If path is '#all', we replace the entire document
-          if (value === '#delete') {
-            // If value is '#delete', we delete the document
-            return { _id: docId, _deleted: true }
-          }
           return {
             ...doc,
             ...value


### PR DESCRIPTION
**在删除某个收藏后，CPU会出现持续的高占用**。这主要是因为收藏的删除逻辑使用 upsert 方法将文档值设为 {_deleta: true} 来删除文档，这会触发 PouchDB 内部的冲突，产生无限重试，进而导致持续的高 CPU 占用。

本提交将删除逻辑替换为使用remove方法，以解决该问题。
