### PR TITLE
Fix i18n related logic in steam scraper

### DIFF
--- a/src/main/features/scraper/providers/steam/common.ts
+++ b/src/main/features/scraper/providers/steam/common.ts
@@ -277,25 +277,56 @@ export async function getGameBackgrounds(appId: string): Promise<string[]> {
 }
 
 export async function getGameCover(appId: string): Promise<string> {
-  const hdUrl = `${STEAM_URLS.CDN}/steam/apps/${appId}/library_600x900_2x.jpg`
-  const standardUrl = `${STEAM_URLS.CDN}/steam/apps/${appId}/library_600x900.jpg`
+  const langConfig = i18next.t('scraper:steam.config', {
+    returnObjects: true
+  }) as SteamLanguageConfig
 
-  // Check if HD image exists
-  const hdExists = await checkImageExists(hdUrl)
+  const candidateUrl = [
+    ...(langConfig.apiLanguageCode
+      ? [
+          `${STEAM_URLS.CDN}/steam/apps/${appId}/library_600x900_${langConfig.apiLanguageCode}_2x.jpg`,
+          `${STEAM_URLS.CDN}/steam/apps/${appId}/library_600x900_${langConfig.apiLanguageCode}.jpg`
+        ]
+      : []),
+    `${STEAM_URLS.CDN}/steam/apps/${appId}/library_600x900_2x.jpg`
+  ]
+  const fallbackUrl = `${STEAM_URLS.CDN}/steam/apps/${appId}/library_600x900.jpg`
 
-  // If HD image exists, return HD image URL, otherwise return standard image URL
-  return hdExists ? hdUrl : standardUrl
+  // Try all candidate URLs and return the first one that exists
+  for (const url of candidateUrl) {
+    if (await checkImageExists(url)) {
+      return url
+    }
+  }
+
+  // If no candidate URLs exist, return fallback URL
+  // TODO: Some newer games use URLs containing a {hash} segment instead of the standard pattern
+  return fallbackUrl
 }
 
 export async function getGameLogo(appId: string): Promise<string> {
-  const hdUrl = `${STEAM_URLS.CDN}/steam/apps/${appId}/logo_2x.png`
-  const standardUrl = `${STEAM_URLS.CDN}/steam/apps/${appId}/logo.png`
+  const langConfig = i18next.t('scraper:steam.config', {
+    returnObjects: true
+  }) as SteamLanguageConfig
 
-  // Check if HD image exists
-  const hdExists = await checkImageExists(hdUrl)
+  const candidateUrl = [
+    ...(langConfig.apiLanguageCode
+      ? [
+          `${STEAM_URLS.CDN}/steam/apps/${appId}/logo_${langConfig.apiLanguageCode}_2x.png`,
+          `${STEAM_URLS.CDN}/steam/apps/${appId}/logo_${langConfig.apiLanguageCode}.png`
+        ]
+      : []),
+    `${STEAM_URLS.CDN}/steam/apps/${appId}/logo_2x.png`
+  ]
+  const fallbackUrl = `${STEAM_URLS.CDN}/steam/apps/${appId}/logo.png`
 
-  // If HD image exists, return HD image URL, otherwise return standard image URL
-  return hdExists ? hdUrl : standardUrl
+  // Try all candidate URLs and return the first one that exists
+  for (const url of candidateUrl) {
+    if (await checkImageExists(url)) {
+      return url
+    }
+  }
+  return fallbackUrl
 }
 
 export async function checkSteamGameExists(appId: string): Promise<boolean> {


### PR DESCRIPTION
### 优化了steam数据源对于锁区游戏的搜索

将steam数据源的搜索逻辑更改为在多个地区尝试搜索后合并，以解决无法搜索到锁区游戏的问题

fix #493

### 优化了steam数据源多语言变种资源的获取

对于steam数据源的封面与徽标，优先尝试获取其带有语言变种的版本，不存在时再回退到默认版本

fix #216
