### PR TITLE
feat(scraper): support caching for description images

### DIFF
--- a/src/main/core/database/layers/GameDBManager.ts
+++ b/src/main/core/database/layers/GameDBManager.ts
@@ -418,6 +418,37 @@ export class GameDBManager {
     }
   }
 
+  static async setGameDescriptionImage(
+    gameId: string,
+    hash: string,
+    image: Buffer | string
+  ): Promise<void> {
+    try {
+      image = await convertToWebP(image)
+      await baseDBManager.putAttachment(
+        this.DB_NAME,
+        gameId,
+        `images/description/${hash}.webp`,
+        image
+      )
+    } catch (error) {
+      log.error('[GameDB] Error setting game image:', error)
+      throw error
+    }
+  }
+
+  static async listGameDescriptionImageHashes(gameId: string): Promise<string[]> {
+    try {
+      const attachments = await baseDBManager.listAttachmentNames(this.DB_NAME, gameId)
+      return Object.keys(attachments)
+        .filter((key) => key.startsWith('images/description/') && key.endsWith('.webp'))
+        .map((key) => key.substring(19, key.length - 5)) // Extract hash from attachment id
+    } catch (error) {
+      log.error('[GameDB] Error listing game description image hashes:', error)
+      throw error
+    }
+  }
+
   static async setGameSave(
     gameId: string,
     saveId: string,
@@ -488,6 +519,15 @@ export class GameDBManager {
       await baseDBManager.removeAttachment(this.DB_NAME, gameId, `images/${type}.webp`)
     } catch (error) {
       log.error('[GameDB] Error removing game image:', error)
+      throw error
+    }
+  }
+
+  static async removeGameDescriptionImage(gameId: string, hash: string): Promise<void> {
+    try {
+      await baseDBManager.removeAttachment(this.DB_NAME, gameId, `images/description/${hash}.webp`)
+    } catch (error) {
+      log.error('[GameDB] Error removing game description image:', error)
       throw error
     }
   }

--- a/src/main/features/adder/services/adder.ts
+++ b/src/main/features/adder/services/adder.ts
@@ -17,6 +17,7 @@ import { ConfigDBManager, GameDBManager } from '~/core/database'
 import { eventBus } from '~/core/events'
 import { saveGameIconByFile } from '~/features/game'
 import { launcherPreset } from '~/features/launcher'
+import { cacheDescriptionImages } from '~/features/scraper/services/descriptionImageCache'
 import { scraperManager } from '~/features/scraper'
 import { getGameFolders, selectPathDialog } from '~/utils'
 
@@ -407,6 +408,8 @@ export async function addGameToDB({
 
     // Execute all database operations (in parallel)
     await Promise.all(dbPromises)
+
+    await cacheDescriptionImages(metadata.description, dbId)
 
     // Set the launcher preset
     if (gamePath) await launcherPreset('default', dbId)

--- a/src/main/features/adder/services/updater.ts
+++ b/src/main/features/adder/services/updater.ts
@@ -18,6 +18,7 @@ import {
 } from '@appTypes/utils'
 import { GameDBManager } from '~/core/database'
 import { scraperManager } from '~/features/scraper'
+import { cacheDescriptionImages } from '~/features/scraper/services/descriptionImageCache'
 import { ipcManager } from '~/core/ipc'
 import log from 'electron-log/main'
 
@@ -952,6 +953,8 @@ export async function updateGameMetadata({
 
     // Execute all database operations in parallel
     await Promise.all(dbPromises)
+
+    await cacheDescriptionImages(updatedMetadata.description, dbId)
   } catch (error) {
     log.error('[MetadataUpdater] Failed to update game metadata:', error)
     throw error

--- a/src/main/features/importer/services/versionConverter/common.ts
+++ b/src/main/features/importer/services/versionConverter/common.ts
@@ -560,7 +560,8 @@ async function convertConfig(basePath: string): Promise<void> {
       scraper: {
         common: {
           defaultDataSource: mapDataSourceName(v2Config.scraper.defaultDataSource),
-          defaultMediaDataSource: 'google'
+          defaultMediaDataSource: 'google',
+          cacheDescriptionImages: false
         },
         vndb: {
           tagSpoilerLevel: 0

--- a/src/main/features/scraper/services/descriptionImageCache.ts
+++ b/src/main/features/scraper/services/descriptionImageCache.ts
@@ -1,0 +1,148 @@
+import { createHash } from 'crypto'
+import { GameDBManager, ConfigDBManager } from '~/core/database'
+import log from 'electron-log/main'
+
+/**
+ * Generate MD5 hash for a URL
+ */
+function getUrlHash(url: string): string {
+  return createHash('md5').update(url).digest('hex')
+}
+
+/**
+ * Extract unique image URLs from HTML description (img src and video poster)
+ * Returns an array of unique URLs
+ */
+function extractUniqueImageUrls(html: string): string[] {
+  const urlSet = new Set<string>()
+
+  // Match img src
+  const imgRegex = /<img[^>]+src=["']([^"']+)["'][^>]*>/gi
+  let match
+  while ((match = imgRegex.exec(html)) !== null) {
+    urlSet.add(match[1])
+  }
+
+  // Match video poster
+  const videoRegex = /<video[^>]+poster=["']([^"']+)["'][^>]*>/gi
+  while ((match = videoRegex.exec(html)) !== null) {
+    urlSet.add(match[1])
+  }
+
+  return Array.from(urlSet)
+}
+
+/**
+ * From HTML description, extract image URLs and generate hashes
+ * @returns Map<originalUrl, hash> - mapping from original URL to hash
+ */
+function extractDescriptionImageUrls(description: string): Map<string, string> {
+  const images = new Map<string, string>()
+  if (!description) return images
+
+  const urls = extractUniqueImageUrls(description)
+  const newUrls = urls.filter((url) => !url.startsWith('data:') && !url.startsWith('attachment://'))
+
+  for (const url of newUrls) {
+    const hash = getUrlHash(url)
+    images.set(url, hash)
+  }
+
+  return images
+}
+
+/**
+ * Replace description URLs with cached attachment URLs for successfully cached images
+ * @param description - original HTML description
+ * @param gameId - game ID for constructing attachment URL
+ * @param cachedUrls - mapping of successfully cached URLs to their hashes
+ * @returns description with replaced URLs
+ */
+function replaceDescriptionUrls(
+  description: string,
+  gameId: string,
+  cachedUrls: Map<string, string>
+): string {
+  if (!description || cachedUrls.size === 0) return description
+
+  let result = description
+  for (const [originalUrl, hash] of cachedUrls) {
+    const attachmentUrl = `attachment://game/${gameId}/images/description/${hash}.webp`
+    result = result.split(originalUrl).join(attachmentUrl)
+  }
+  return result
+}
+
+export async function cacheDescriptionImages(description: string, gameId: string): Promise<void> {
+  if (!description) {
+    return
+  }
+
+  const cacheEnabled = await ConfigDBManager.getConfigValue(
+    'game.scraper.common.cacheDescriptionImages'
+  )
+  if (!cacheEnabled) {
+    return
+  }
+
+  const descriptionImageUrls = extractDescriptionImageUrls(description)
+  if (descriptionImageUrls.size === 0) {
+    return
+  }
+
+  // Get existing cached hashes to skip already cached images
+  const existingHashes = await GameDBManager.listGameDescriptionImageHashes(gameId)
+  const existingHashSet = new Set(existingHashes)
+
+  const newImageEntries: [string, string][] = []
+  const cachedUrls = new Map<string, string>()
+  const neededHashes = new Set<string>()
+
+  for (const [originalUrl, hash] of descriptionImageUrls) {
+    neededHashes.add(hash)
+    if (existingHashSet.has(hash)) {
+      cachedUrls.set(originalUrl, hash)
+    } else {
+      newImageEntries.push([originalUrl, hash])
+    }
+  }
+
+  // Download new images in parallel
+  if (newImageEntries.length > 0) {
+    const results = await Promise.allSettled(
+      newImageEntries.map(async ([originalUrl, hash]) => {
+        await GameDBManager.setGameDescriptionImage(gameId, hash, originalUrl)
+        return { originalUrl, hash }
+      })
+    )
+
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        cachedUrls.set(result.value.originalUrl, result.value.hash)
+      } else {
+        log.warn(
+          `[DescriptionImageCache] Failed to cache description image:`,
+          result.status === 'rejected' ? result.reason : 'unknown error'
+        )
+      }
+    }
+  }
+
+  // Clean up orphaned cache images in parallel
+  const orphanedHashes = existingHashes.filter((hash) => !neededHashes.has(hash))
+  if (orphanedHashes.length > 0) {
+    await Promise.all(
+      orphanedHashes.map((hash) =>
+        GameDBManager.removeGameDescriptionImage(gameId, hash).catch((err) => {
+          log.warn(`[DescriptionImageCache] Failed to remove orphaned cache image ${hash}:`, err)
+        })
+      )
+    )
+  }
+
+  // Update description with cached URLs
+  if (cachedUrls.size > 0) {
+    const newDescription = replaceDescriptionUrls(description, gameId, cachedUrls)
+    await GameDBManager.setGameValue(gameId, 'metadata.description', newDescription)
+  }
+}

--- a/src/renderer/locales/en/config.json
+++ b/src/renderer/locales/en/config.json
@@ -304,7 +304,9 @@
       "defaultDataSource": "Default Data Source",
       "defaultDataSourceDescription": "Choose default data source",
       "defaultMediaDataSource": "Default Media Data Source",
-      "defaultMediaDataSourceDescription": "Select the default search data source used on the “Properties → Media” page\nSome data sources do not support icon or logo searches. If the selected default source is unavailable, the system will automatically fall back to Google"
+      "defaultMediaDataSourceDescription": "Select the default search data source used on the \"Properties → Media\" page\nSome data sources do not support icon or logo searches. If the selected default source is unavailable, the system will automatically fall back to Google",
+      "cacheDescriptionImages": "Cache Description Images",
+      "cacheDescriptionImagesDescription": "Download and cache images in game descriptions locally for offline viewing and faster loading"
     },
     "vndb": {
       "title": "VNDB Settings",

--- a/src/renderer/locales/fr/config.json
+++ b/src/renderer/locales/fr/config.json
@@ -165,7 +165,9 @@
     "title": "",
     "common": {
       "title": "",
-      "defaultDataSource": ""
+      "defaultDataSource": "",
+      "cacheDescriptionImages": "",
+      "cacheDescriptionImagesDescription": ""
     },
     "vndb": {
       "title": "",

--- a/src/renderer/locales/it/config.json
+++ b/src/renderer/locales/it/config.json
@@ -169,7 +169,9 @@
     "title": "",
     "common": {
       "title": "",
-      "defaultDataSource": ""
+      "defaultDataSource": "",
+      "cacheDescriptionImages": "",
+      "cacheDescriptionImagesDescription": ""
     },
     "vndb": {
       "title": "",

--- a/src/renderer/locales/ja/config.json
+++ b/src/renderer/locales/ja/config.json
@@ -304,7 +304,9 @@
       "defaultDataSource": "デフォルトデータソース",
       "defaultDataSourceDescription": "デフォルトデータソースを選択",
       "defaultMediaDataSource": "デフォルトのメディアデータソース",
-      "defaultMediaDataSourceDescription": "「プロパティ → メディア」ページで使用するデフォルトの検索データソースを選択\n一部のデータソースはアイコンまたはロゴ検索に対応していません。選択したデフォルトデータソースが利用できない場合は、自動的に「Google」にフォールバックします"
+      "defaultMediaDataSourceDescription": "「プロパティ → メディア」ページで使用するデフォルトの検索データソースを選択\n一部のデータソースはアイコンまたはロゴ検索に対応していません。選択したデフォルトデータソースが利用できない場合は、自動的に「Google」にフォールバックします",
+      "cacheDescriptionImages": "説明文の画像をキャッシュ",
+      "cacheDescriptionImagesDescription": "ゲームの説明文に含まれる画像をローカルにダウンロード・キャッシュし、オフライン閲覧と読み込み速度の向上を実現します"
     },
     "vndb": {
       "title": "VNDB 設定",

--- a/src/renderer/locales/ko/config.json
+++ b/src/renderer/locales/ko/config.json
@@ -194,7 +194,9 @@
     "title": "스크래퍼",
     "common": {
       "title": "일반",
-      "defaultDataSource": "기본 자료 출처"
+      "defaultDataSource": "기본 자료 출처",
+      "cacheDescriptionImages": "설명 이미지 캐시",
+      "cacheDescriptionImagesDescription": "게임 설명의 이미지를 로컬에 다운로드하고 캐시하여 오프라인에서도 확인할 수 있고 로딩 속도를 향상시킵니다"
     },
     "vndb": {
       "title": "VNDB 설정",

--- a/src/renderer/locales/ru/config.json
+++ b/src/renderer/locales/ru/config.json
@@ -163,7 +163,9 @@
     "title": "Поиск данных",
     "common": {
       "title": "Общие",
-      "defaultDataSource": "Источник данных по умолчанию"
+      "defaultDataSource": "Источник данных по умолчанию",
+      "cacheDescriptionImages": "Кэшировать изображения описания",
+      "cacheDescriptionImagesDescription": "Загружать и кэшировать изображения из описаний игр локально для просмотра офлайн и быстрой загрузки"
     },
     "vndb": {
       "title": "Настройки VNDB",

--- a/src/renderer/locales/zh-CN/config.json
+++ b/src/renderer/locales/zh-CN/config.json
@@ -304,7 +304,9 @@
       "defaultDataSource": "默认数据源",
       "defaultDataSourceDescription": "选择默认数据源",
       "defaultMediaDataSource": "默认媒体数据源",
-      "defaultMediaDataSourceDescription": "选择“属性 → 媒体”页面使用的默认搜索数据源\n部分数据源不支持图标或徽标搜索；当所选默认数据源不可用时，将自动回退至「Google」"
+      "defaultMediaDataSourceDescription": "选择“属性 → 媒体”页面使用的默认搜索数据源\n部分数据源不支持图标或徽标搜索；当所选默认数据源不可用时，将自动回退至「Google」",
+      "cacheDescriptionImages": "缓存简介内图片到本地",
+      "cacheDescriptionImagesDescription": "将游戏简介中的图片下载并缓存到本地，以实现离线查看和加快加载速度"
     },
     "vndb": {
       "title": "VNDB 设置",

--- a/src/renderer/locales/zh-TW/config.json
+++ b/src/renderer/locales/zh-TW/config.json
@@ -304,7 +304,9 @@
       "defaultDataSource": "預設資料源",
       "defaultDataSourceDescription": "選擇預設資料來源",
       "defaultMediaDataSource": "預設媒體資料來源",
-      "defaultMediaDataSourceDescription": "選擇「屬性 → 媒體」頁面使用的預設搜尋資料來源\n部分資料來源不支援圖示或徽標搜尋；當所選預設資料來源不可用時，將自動回退至「Google」"
+      "defaultMediaDataSourceDescription": "選擇「屬性 → 媒體」頁面使用的預設搜尋資料來源\n部分資料來源不支援圖示或徽標搜尋；當所選預設資料來源不可用時，將自動回退至「Google」",
+      "cacheDescriptionImages": "快取簡介圖片到本機",
+      "cacheDescriptionImagesDescription": "將遊戲簡介中的圖片下載並快取到本機，以實現離線檢視和加快載入速度"
     },
     "vndb": {
       "title": "VNDB 設置",

--- a/src/renderer/src/pages/Config/Scraper.tsx
+++ b/src/renderer/src/pages/Config/Scraper.tsx
@@ -81,6 +81,16 @@ export function Scraper(): React.JSX.Element {
                 controlClassName="w-[200px]"
               />
             </div>
+
+            <div className={cn('space-y-4')}>
+              <ConfigItem
+                hookType="config"
+                path="game.scraper.common.cacheDescriptionImages"
+                title={t('scraper.common.cacheDescriptionImages')}
+                controlType="switch"
+                description={t('scraper.common.cacheDescriptionImagesDescription')}
+              />
+            </div>
           </div>
 
           {/* VNDB Settings */}

--- a/src/types/models/config.ts
+++ b/src/types/models/config.ts
@@ -41,6 +41,7 @@ export interface configDocs {
       common: {
         defaultDataSource: 'steam' | 'vndb' | 'bangumi' | 'ymgal' | 'igdb' | 'dlsite' | string
         defaultMediaDataSource: 'google' | string
+        cacheDescriptionImages: boolean
       }
       vndb: {
         tagSpoilerLevel: 0 | 1 | 2
@@ -321,7 +322,8 @@ export const DEFAULT_CONFIG_VALUES: Readonly<configDocs> = {
     scraper: {
       common: {
         defaultDataSource: 'steam',
-        defaultMediaDataSource: 'google'
+        defaultMediaDataSource: 'google',
+        cacheDescriptionImages: false
       },
       vndb: {
         tagSpoilerLevel: 0


### PR DESCRIPTION
在刮削器通用配置中增加了"缓存简介内图片到本地"选项.
开启该选项后会在刮削简介时将简介内的图片(img标签与video标签的poster)缓存到数据库内, 方便离线查看.
该选项默认关闭.