### PR TITLE
fix: fix incorrect display of the scan mode value in the scanner edit dialog

### DIFF
--- a/src/renderer/src/pages/GameScannerManager/store.ts
+++ b/src/renderer/src/pages/GameScannerManager/store.ts
@@ -225,10 +225,7 @@ export const useGameScannerStore = create<GameScannerStore>((set, get) => ({
           : typeof legacyDepth === 'number'
             ? legacyDepth - 1
             : 0
-      const inferredMode =
-        scanner.scanMode === 'hierarchy' || typeof scanner.hierarchyLevel === 'number'
-          ? 'hierarchy'
-          : 'auto'
+      const inferredMode = scanner.scanMode === 'hierarchy' ? 'hierarchy' : 'auto'
 
       set({
         formState: {


### PR DESCRIPTION
修复扫描目录编辑窗口显示的扫描模式值错误(Fix #535)