### PR TITLE
Security: Privileged IPC handlers lack sender/origin validation

### DIFF
--- a/src/main/core/ipc/IPCManager.ts
+++ b/src/main/core/ipc/IPCManager.ts
@@ -23,7 +23,13 @@ export class IPCManager {
       ...args: ExtractArgs<IpcMainEvents>[E]
     ) => void | Promise<void>
   ): void {
-    this.listener.on(channel, listener)
+    this.listener.on(channel, (e, ...args) => {
+      if (!this.isTrustedSender(e.sender)) {
+        console.warn(`Blocked untrusted IPC event on channel: ${String(channel)}`)
+        return
+      }
+      return listener(e, ...args)
+    })
   }
 
   handle<E extends keyof ExtractHandler<IpcMainEvents>>(
@@ -35,7 +41,12 @@ export class IPCManager {
       | ReturnType<ExtractHandler<IpcMainEvents>[E]>
       | Promise<ReturnType<ExtractHandler<IpcMainEvents>[E]>>
   ): void {
-    this.listener.handle(channel, listener)
+    this.listener.handle(channel, async (e, ...args) => {
+      if (!this.isTrustedSender(e.sender)) {
+        throw new Error(`Unauthorized IPC sender for channel: ${String(channel)}`)
+      }
+      return listener(e, ...args)
+    })
   }
 
   dispose(): void {


### PR DESCRIPTION
## Summary

Security: Privileged IPC handlers lack sender/origin validation

## Problem

**Severity**: `High` | **File**: `src/main/core/ipc/IPCManager.ts:L15`

The IPC manager registers handlers/listeners without validating the sender frame origin, URL, or trust level. Any renderer that can access IPC may invoke sensitive main-process operations (database writes, filesystem actions, updater actions, plugin lifecycle), creating a high-impact privilege-escalation path if renderer content is compromised.

## Solution

Implement centralized sender validation (e.g., allowlist trusted origins/windows/webContents IDs) before dispatching handlers. Add per-channel authorization checks and minimize exposed channels. Consider context isolation + strict preload API surface with explicit permission checks.

## Changes

- `src/main/core/ipc/IPCManager.ts` (modified)