### PR TITLE
fix: handle deferred game database loading in library sidebar

### DIFF
--- a/src/renderer/src/components/Librarybar/main.tsx
+++ b/src/renderer/src/components/Librarybar/main.tsx
@@ -1,15 +1,19 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { eventBus } from '~/app/events'
 import { useConfigState } from '~/hooks'
+import { useGameRegistry } from '~/stores/game'
 import { cn } from '~/utils'
 import { GameList } from './GameList'
 import { PositionButton } from './PositionButton'
 import { useLibrarybarStore } from './store'
-import { eventBus } from '~/app/events'
-import { useEffect } from 'react'
 
 export function Librarybar(): React.JSX.Element {
   const [selectedGroup] = useConfigState('game.gameList.selectedGroup')
   const query = useLibrarybarStore((state) => state.query)
   const refreshGameList = useLibrarybarStore((state) => state.refreshGameList)
+  const gamesLoaded = useGameRegistry((state) => state.gamesLoaded)
+  const { t } = useTranslation('game')
 
   console.warn(`[DEBUG] Librarybar`)
 
@@ -26,6 +30,19 @@ export function Librarybar(): React.JSX.Element {
       unsubscribeGameDeleted()
     }
   }, [])
+
+  if (!gamesLoaded) {
+    return (
+      <div className={cn('flex flex-col gap-1 items-center justify-center w-full h-full -mt-7')}>
+        <div
+          className={cn(
+            'animate-spin w-8 h-8 border-2 border-primary border-t-transparent rounded-full'
+          )}
+        />
+        <div className={cn('text-muted-foreground mt-2')}>{t('showcase.loadingGames')}</div>
+      </div>
+    )
+  }
 
   return (
     <div className={cn('flex flex-col gap-6 bg-transparent w-full h-full relative group shrink-0')}>


### PR DESCRIPTION
修复程序启动后游戏列表不加载的问题。

该问题与 #551 引入的数据库分阶段加载相关，其虽然在主页的内容显示区订阅了加载完成状态，但是左侧的游戏列表没有订阅该状态，导致数据库加载完成后列表没有重新渲染。

较为有趣的是，在开发模式下使用大规模的游戏数据库未能复现该问题，推测可能是某处未知的状态更新触发了列表的重渲染；换为规模较小的游戏数据库才成功复现。

Fix #576