### PR TITLE
feat: show grouped sort summaries in game list headers

### DIFF
--- a/src/renderer/src/components/Librarybar/GameList/AllGame.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/AllGame.tsx
@@ -5,6 +5,7 @@ import { useConfigState } from '~/hooks'
 import { filterGamesByLocal, filterGamesByNSFW, sortGames } from '~/stores/game'
 import { cn } from '~/utils'
 import { GameNav } from '../GameNav'
+import { GroupSortSummary } from './GroupSortSummary'
 import { PlaceHolder } from './PlaceHolder'
 
 export function AllGameComponent({
@@ -29,6 +30,7 @@ export function AllGameComponent({
         <div className={cn('flex flex-row items-center justify-start gap-1')}>
           <div className={cn('text-xs')}>{t('list.all.title')}</div>
           <div className={cn('text-2xs text-foreground/50')}>({games.length})</div>
+          <GroupSortSummary gameIds={games} by={by} />
         </div>
       </AccordionTrigger>
       <AccordionContent className={cn('rounded-none pt-1 flex flex-col gap-1')}>

--- a/src/renderer/src/components/Librarybar/GameList/Collection.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/Collection.tsx
@@ -11,6 +11,7 @@ import { cn } from '~/utils'
 import { GameNav } from '../GameNav'
 import { useGameListStore } from '../store'
 import { AllGameComponent } from './AllGame'
+import { GroupSortSummary } from './GroupSortSummary'
 import { PlaceHolder } from './PlaceHolder'
 import { RecentGames } from './RecentGames'
 
@@ -79,6 +80,7 @@ export function CollectionComponent({
                     <div className={cn('flex flex-row items-center justify-start gap-1')}>
                       <div className={cn('text-xs')}>{value.name}</div>
                       <div className={cn('text-2xs text-foreground/50')}>({gameIds.length})</div>
+                      <GroupSortSummary gameIds={gameIds} by={by} />
                     </div>
                   </AccordionTrigger>
                 </CollectionCM>
@@ -107,6 +109,7 @@ export function CollectionComponent({
                   <div className={cn('text-2xs text-foreground/50')}>
                     ({uncollectedGameIds.length})
                   </div>
+                  <GroupSortSummary gameIds={uncollectedGameIds} by={by} />
                 </div>
               </AccordionTrigger>
               <AccordionContent className={cn('rounded-none pt-1 flex flex-col gap-1 w-full')}>

--- a/src/renderer/src/components/Librarybar/GameList/FilterGame.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/FilterGame.tsx
@@ -7,6 +7,7 @@ import { filterGames, sortGames } from '~/stores/game'
 import { cn } from '~/utils'
 import { useFilterStore } from '../Filter/store'
 import { GameNav } from '../GameNav'
+import { GroupSortSummary } from './GroupSortSummary'
 import { PlaceHolder } from './PlaceHolder'
 
 export function FilterGameComponent({
@@ -28,7 +29,11 @@ export function FilterGameComponent({
       >
         <AccordionItem value="filter">
           <AccordionTrigger className={cn('text-xs p-1 pl-2')}>
-            {t('list.filter.results')}
+            <div className={cn('flex flex-row items-center justify-start gap-1')}>
+              <div className={cn('text-xs')}>{t('list.filter.results')}</div>
+              <div className={cn('text-2xs text-foreground/50')}>({games.length})</div>
+              <GroupSortSummary gameIds={games} by={by} />
+            </div>
           </AccordionTrigger>
           <AccordionContent className={cn('rounded-none pt-1 flex flex-col gap-1')}>
             {games.length !== 0 ? (

--- a/src/renderer/src/components/Librarybar/GameList/GroupSortSummary.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/GroupSortSummary.tsx
@@ -1,0 +1,231 @@
+import type { configDocs } from '@appTypes/models/config'
+import { STORAGE_SIZE_NOT_CALCULATED } from '@appTypes/models/game'
+import { useEffect, useMemo, useState } from 'react'
+import { getGameStore, type SingleGameState } from '~/stores/game'
+import { cn, formatDurationCompact, formatStorageSize } from '~/utils'
+
+type GameListSortBy = configDocs['game']['gameList']['sort']['by']
+type SummarySortBy = Extract<
+  GameListSortBy,
+  'record.playTime' | 'record.score' | 'record.storageSize'
+>
+
+type GroupSortSummaryData =
+  | {
+      type: 'playTime'
+      totalPlayTime: number
+    }
+  | {
+      type: 'score'
+      averageScore: number
+    }
+  | {
+      type: 'storageSize'
+      totalStorageSize: number
+      calculatedCount: number
+      totalCount: number
+    }
+  | null
+
+function isSummarySortBy(by: GameListSortBy): by is SummarySortBy {
+  return by === 'record.playTime' || by === 'record.score' || by === 'record.storageSize'
+}
+
+function summariesEqual(a: GroupSortSummaryData, b: GroupSortSummaryData): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+
+  if (a.type === 'playTime' && b.type === 'playTime') {
+    return a.totalPlayTime === b.totalPlayTime
+  }
+
+  if (a.type === 'score' && b.type === 'score') {
+    return a.averageScore === b.averageScore
+  }
+
+  if (a.type === 'storageSize' && b.type === 'storageSize') {
+    return (
+      a.totalStorageSize === b.totalStorageSize &&
+      a.calculatedCount === b.calculatedCount &&
+      a.totalCount === b.totalCount
+    )
+  }
+
+  return false
+}
+
+function computeGroupSortSummary(gameIds: string[], by: GameListSortBy): GroupSortSummaryData {
+  if (gameIds.length === 0 || !isSummarySortBy(by)) {
+    return null
+  }
+
+  switch (by) {
+    case 'record.playTime': {
+      const totalPlayTime = gameIds.reduce((total, gameId) => {
+        const playTime = getGameStore(gameId).getState().getValue('record.playTime')
+        return total + (Number.isFinite(playTime) ? Math.max(0, playTime) : 0)
+      }, 0)
+
+      return totalPlayTime > 0 ? { type: 'playTime', totalPlayTime } : null
+    }
+
+    case 'record.score': {
+      let totalScore = 0
+      let ratedCount = 0
+
+      for (const gameId of gameIds) {
+        const score = getGameStore(gameId).getState().getValue('record.score')
+        if (Number.isFinite(score) && score !== -1) {
+          totalScore += score
+          ratedCount += 1
+        }
+      }
+
+      return ratedCount > 0 ? { type: 'score', averageScore: totalScore / ratedCount } : null
+    }
+
+    case 'record.storageSize': {
+      let totalStorageSize = 0
+      let calculatedCount = 0
+
+      for (const gameId of gameIds) {
+        const storageSize = getGameStore(gameId).getState().getValue('record.storageSize')
+        if (
+          Number.isFinite(storageSize) &&
+          storageSize !== STORAGE_SIZE_NOT_CALCULATED &&
+          storageSize >= 0
+        ) {
+          totalStorageSize += storageSize
+          calculatedCount += 1
+        }
+      }
+
+      return calculatedCount > 0
+        ? {
+            type: 'storageSize',
+            totalStorageSize,
+            calculatedCount,
+            totalCount: gameIds.length
+          }
+        : null
+    }
+  }
+}
+
+function getObservedSortValue(state: Pick<SingleGameState, 'data'>, by: SummarySortBy): number {
+  switch (by) {
+    case 'record.playTime':
+      return state.data?.record.playTime ?? 0
+    case 'record.score':
+      return state.data?.record.score ?? -1
+    case 'record.storageSize':
+      return state.data?.record.storageSize ?? STORAGE_SIZE_NOT_CALCULATED
+  }
+}
+
+const FNV_64_OFFSET_BASIS = 0xcbf29ce484222325n
+const FNV_64_PRIME = 0x100000001b3n
+const UINT64_MASK = (1n << 64n) - 1n
+
+// fnv-1a 64-bit hash implementation for string inputs
+function hashString64(input: string): bigint {
+  let hash = FNV_64_OFFSET_BASIS
+
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= BigInt(input.charCodeAt(index))
+    hash = (hash * FNV_64_PRIME) & UINT64_MASK
+  }
+
+  return hash
+}
+
+function getGameIdsMembershipHash(gameIds: string[]): string {
+  const uniqueGameIds = new Set(gameIds)
+  let xor = 0n
+  let sum = 0n
+  let count = 0
+
+  for (const gameId of uniqueGameIds) {
+    const hash = hashString64(gameId)
+    xor ^= hash
+    sum = (sum + hash) & UINT64_MASK
+    count += 1
+  }
+
+  return `${count}:${xor.toString(16)}:${sum.toString(16)}`
+}
+
+function useGroupSortSummary(gameIds: string[], by: GameListSortBy): GroupSortSummaryData {
+  const gameIdsMembershipHash = useMemo(() => getGameIdsMembershipHash(gameIds), [gameIds])
+  const [summary, setSummary] = useState<GroupSortSummaryData>(() =>
+    computeGroupSortSummary(gameIds, by)
+  )
+
+  useEffect(() => {
+    const nextSummary = computeGroupSortSummary(gameIds, by)
+    setSummary((prev) => (summariesEqual(prev, nextSummary) ? prev : nextSummary))
+
+    if (!isSummarySortBy(by) || gameIds.length === 0) {
+      return
+    }
+
+    const unsubscribes = gameIds.map((gameId) =>
+      getGameStore(gameId).subscribe((state, prevState) => {
+        if (getObservedSortValue(state, by) === getObservedSortValue(prevState, by)) {
+          // Avoid unnecessary recomputation as much as possible
+          return
+        }
+
+        const updatedSummary = computeGroupSortSummary(gameIds, by)
+        setSummary((prev) => (summariesEqual(prev, updatedSummary) ? prev : updatedSummary))
+      })
+    )
+
+    return () => {
+      unsubscribes.forEach((unsubscribe) => unsubscribe())
+    }
+  }, [by, gameIdsMembershipHash])
+
+  return summary
+}
+
+export function GroupSortSummary({
+  gameIds,
+  by,
+  className
+}: {
+  gameIds: string[]
+  by: GameListSortBy
+  className?: string
+}): React.JSX.Element | null {
+  const summary = useGroupSortSummary(gameIds, by)
+
+  if (!summary) {
+    return null
+  }
+
+  let content: string | null = null
+  switch (summary.type) {
+    case 'playTime':
+      content = `(${formatDurationCompact(summary.totalPlayTime)})`
+      break
+    case 'score':
+      if (summary.averageScore < 0) {
+        return null
+      }
+      content = `(avg: ${summary.averageScore.toFixed(1)})`
+      break
+    case 'storageSize':
+      if (summary.totalStorageSize <= 0) {
+        return null
+      }
+      content = `(${formatStorageSize(summary.totalStorageSize)}${
+        summary.calculatedCount < summary.totalCount
+          ? `, ${summary.calculatedCount}/${summary.totalCount}`
+          : ''
+      })`
+      break
+  }
+
+  return <span className={cn('text-2xs text-foreground/50', className)}>{content}</span>
+}

--- a/src/renderer/src/components/Librarybar/GameList/Others.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/Others.tsx
@@ -14,6 +14,7 @@ import { cn } from '~/utils'
 import { GameNav } from '../GameNav'
 import { useGameListStore } from '../store'
 import { AllGameComponent } from './AllGame'
+import { GroupSortSummary } from './GroupSortSummary'
 import { PlaceHolder } from './PlaceHolder'
 import { RecentGames } from './RecentGames'
 
@@ -74,6 +75,7 @@ function OthersComponent({
                         {field !== '__empty__' ? field : emptyAccordionName[fieldName]}
                       </div>
                       <div className={cn('text-2xs text-foreground/50')}>({gameIds.length})</div>
+                      <GroupSortSummary gameIds={gameIds} by={by} />
                     </div>
                   </AccordionTrigger>
                   <AccordionContent className={cn('rounded-none pt-1 flex flex-col gap-1')}>

--- a/src/renderer/src/components/Librarybar/GameList/PlayStatusGames.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/PlayStatusGames.tsx
@@ -14,6 +14,7 @@ import { cn } from '~/utils'
 import { GameNav } from '../GameNav'
 import { useGameListStore, usePlayStatusOrderStore } from '../store'
 import { AllGameComponent } from './AllGame'
+import { GroupSortSummary } from './GroupSortSummary'
 import { PlaceHolder } from './PlaceHolder'
 import { RecentGames } from './RecentGames'
 
@@ -66,6 +67,7 @@ export function PlayStatusGamesComponent({
                   <div className={cn('flex flex-row items-center justify-start gap-1')}>
                     <div className={cn('text-xs')}>{t(`utils:game.playStatus.${field}`)}</div>
                     <div className={cn('text-2xs text-foreground/50')}>({gameIds.length})</div>
+                    <GroupSortSummary gameIds={gameIds} by={by} />
                   </div>
                 </AccordionTrigger>
                 <AccordionContent className={cn('rounded-none pt-1 flex flex-col gap-1')}>

--- a/src/renderer/src/components/Librarybar/GameList/Search.tsx
+++ b/src/renderer/src/components/Librarybar/GameList/Search.tsx
@@ -6,6 +6,7 @@ import { useConfigState } from '~/hooks'
 import { searchGames, sortGames } from '~/stores/game'
 import { cn } from '~/utils'
 import { GameNav } from '../GameNav'
+import { GroupSortSummary } from './GroupSortSummary'
 import { PlaceHolder } from './PlaceHolder'
 
 export function SearchComponent({
@@ -28,7 +29,11 @@ export function SearchComponent({
       >
         <AccordionItem value="all">
           <AccordionTrigger className={cn('text-xs p-1 pl-2')}>
-            {t('list.search.results')}
+            <div className={cn('flex flex-row items-center justify-start gap-1')}>
+              <div className={cn('text-xs')}>{t('list.search.results')}</div>
+              <div className={cn('text-2xs text-foreground/50')}>({games.length})</div>
+              <GroupSortSummary gameIds={games} by={by} />
+            </div>
           </AccordionTrigger>
           <AccordionContent className={cn('rounded-none pt-1 flex flex-col gap-1')}>
             {games.map((game) => (


### PR DESCRIPTION
支持显示游戏列表各分组的排序信息。

与游戏列表各项的排序信息显示相同，只在排序依据为评分、游玩时间、游戏大小时显示，且不在最近游戏分组显示。对于游玩时间与游戏大小，显示内容为分组内总和；对于评分，显示内容为分组内平均分。

Related #540
