### PR TITLE
Opti/media search

### DIFF
--- a/src/main/features/scraper/providers/steam/common.ts
+++ b/src/main/features/scraper/providers/steam/common.ts
@@ -245,14 +245,18 @@ export async function checkImageExists(url: string): Promise<boolean> {
 }
 
 export async function getGameHero(appId: string): Promise<string> {
-  const hdUrl = `${STEAM_URLS.CDN}/steam/apps/${appId}/library_hero_2x.jpg`
-  const standardUrl = `${STEAM_URLS.CDN}/steam/apps/${appId}/library_hero.jpg`
+  const candidateUrls = [
+    `${STEAM_URLS.CDN}/steam/apps/${appId}/library_hero_2x.jpg`,
+    `${STEAM_URLS.CDN}/steam/apps/${appId}/library_hero.jpg`
+  ]
 
-  // Check if HD image exists
-  const hdExists = await checkImageExists(hdUrl)
+  for (const url of candidateUrls) {
+    if (await checkImageExists(url)) {
+      return url
+    }
+  }
 
-  // If HD image exists, return HD image URL, otherwise return standard image URL
-  return hdExists ? hdUrl : standardUrl
+  return ''
 }
 
 export async function getGameScreenshots(appId: string): Promise<string[]> {
@@ -273,7 +277,7 @@ export async function getGameBackgrounds(appId: string): Promise<string[]> {
   const heroUrl = await getGameHero(appId)
   const screenshots = await getGameScreenshots(appId)
 
-  return [heroUrl, ...screenshots]
+  return heroUrl ? [heroUrl, ...screenshots] : screenshots
 }
 
 export async function getGameCover(appId: string): Promise<string> {
@@ -288,9 +292,9 @@ export async function getGameCover(appId: string): Promise<string> {
           `${STEAM_URLS.CDN}/steam/apps/${appId}/library_600x900_${langConfig.apiLanguageCode}.jpg`
         ]
       : []),
-    `${STEAM_URLS.CDN}/steam/apps/${appId}/library_600x900_2x.jpg`
+    `${STEAM_URLS.CDN}/steam/apps/${appId}/library_600x900_2x.jpg`,
+    `${STEAM_URLS.CDN}/steam/apps/${appId}/library_600x900.jpg`
   ]
-  const fallbackUrl = `${STEAM_URLS.CDN}/steam/apps/${appId}/library_600x900.jpg`
 
   // Try all candidate URLs and return the first one that exists
   for (const url of candidateUrl) {
@@ -299,9 +303,11 @@ export async function getGameCover(appId: string): Promise<string> {
     }
   }
 
-  // If no candidate URLs exist, return fallback URL
-  // TODO: Some newer games use URLs containing a {hash} segment instead of the standard pattern
-  return fallbackUrl
+  // Some newer games use hashed asset paths rather than the standard Steam CDN
+  // naming pattern. Return an empty string here so api.ts can convert it to `[]`
+  // instead of surfacing a broken URL to the renderer.
+  // TODO: Investigate whether the hashed asset URL can be resolved reliably.
+  return ''
 }
 
 export async function getGameLogo(appId: string): Promise<string> {
@@ -316,9 +322,9 @@ export async function getGameLogo(appId: string): Promise<string> {
           `${STEAM_URLS.CDN}/steam/apps/${appId}/logo_${langConfig.apiLanguageCode}.png`
         ]
       : []),
-    `${STEAM_URLS.CDN}/steam/apps/${appId}/logo_2x.png`
+    `${STEAM_URLS.CDN}/steam/apps/${appId}/logo_2x.png`,
+    `${STEAM_URLS.CDN}/steam/apps/${appId}/logo.png`
   ]
-  const fallbackUrl = `${STEAM_URLS.CDN}/steam/apps/${appId}/logo.png`
 
   // Try all candidate URLs and return the first one that exists
   for (const url of candidateUrl) {
@@ -326,7 +332,8 @@ export async function getGameLogo(appId: string): Promise<string> {
       return url
     }
   }
-  return fallbackUrl
+
+  return ''
 }
 
 export async function checkSteamGameExists(appId: string): Promise<boolean> {

--- a/src/main/utils/image.ts
+++ b/src/main/utils/image.ts
@@ -175,9 +175,7 @@ export async function downloadTempImage(url: string): Promise<string> {
           'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
         Accept: 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
         'Accept-Language': 'en-US,en;q=0.9',
-        Referer: new URL(url).origin,
-        'Cache-Control': 'no-cache',
-        Pragma: 'no-cache'
+        Referer: new URL(url).origin
       }
     })
 


### PR DESCRIPTION
### 修复 Steam 刮削器在部分游戏上返回无效资源链接的问题

部分 Steam 游戏的资源地址带有 hash 字段，无法再通过固定的标准路径直接推导。此前刮削器在未探测到有效资源时，仍然会返回一个看似合法的后备链接；但这类链接在部分游戏上实际是无效的。当前端收到这类无效地址后，会表现为图片加载失败，容易让用户误以为是网络或界面异常。

本次修改调整了 Steam 刮削器的返回策略：仅在确认资源地址实际可用时才返回对应链接；如果标准路径下不存在有效资源，则返回空结果，而不再向前端透传无效的后备地址。

### 优化媒体文件搜索流程中的图片下载效率

目前媒体文件搜索窗口在用户选中图片后、进入裁剪前，会先将图片下载到临时目录。此前这一步下载会显式要求重新校验缓存，即使该图片刚刚已经在搜索结果中完成预览，也仍然会再次走一轮强制校验流程。

对于这类游戏资源图片而言，通常属于低频变更的静态资源，强制重新校验带来的收益很低，反而会增加用户在预览完成后的额外等待时间。因此，本次修改移除了该强制校验标志，使这一步能够更好地复用已有缓存，从而提升图片选择后的响应速度。

Fix #595
