### PR TITLE
Opti/big poster

### DIFF
--- a/src/main/core/database/layers/GameDBManager.ts
+++ b/src/main/core/database/layers/GameDBManager.ts
@@ -1,3 +1,4 @@
+import type { GameMediaType } from '@appTypes/models'
 import { baseDBManager } from '../BaseDBManager'
 import { convertToWebP } from '~/utils'
 import {
@@ -317,7 +318,7 @@ export class GameDBManager {
 
   static async setGameImage(
     gameId: string,
-    type: 'background' | 'cover' | 'icon' | 'logo',
+    type: GameMediaType,
     image: Buffer | string
   ): Promise<void> {
     try {
@@ -331,7 +332,7 @@ export class GameDBManager {
 
   static async getGameImage<T extends 'buffer' | 'file' = 'buffer'>(
     gameId: string,
-    type: 'background' | 'cover' | 'icon' | 'logo',
+    type: GameMediaType,
     format: T = 'buffer' as T
   ): Promise<T extends 'file' ? string | null : Buffer | null> {
     try {
@@ -511,10 +512,7 @@ export class GameDBManager {
     }
   }
 
-  static async removeGameImage(
-    gameId: string,
-    type: 'background' | 'cover' | 'icon' | 'logo'
-  ): Promise<void> {
+  static async removeGameImage(gameId: string, type: GameMediaType): Promise<void> {
     try {
       await baseDBManager.removeAttachment(this.DB_NAME, gameId, `images/${type}.webp`)
     } catch (error) {

--- a/src/main/features/game/ipc.ts
+++ b/src/main/features/game/ipc.ts
@@ -1,3 +1,4 @@
+import type { GameMediaType } from '@appTypes/models'
 import sharp from 'sharp'
 import { GameDBManager } from '~/core/database'
 import { ipcManager } from '~/core/ipc'
@@ -19,7 +20,7 @@ import {
 export function setupGameIPC(): void {
   ipcManager.handle(
     'game:set-image',
-    async (_, gameId: string, type: 'background' | 'cover' | 'logo' | 'icon', image: string) => {
+    async (_, gameId: string, type: GameMediaType, image: string) => {
       return await GameDBManager.setGameImage(gameId, type, image)
     }
   )
@@ -90,19 +91,13 @@ export function setupGameIPC(): void {
     }
   )
 
-  ipcManager.handle(
-    'game:get-media-path',
-    async (_, gameId: string, type: 'cover' | 'background' | 'icon' | 'logo') => {
-      return await GameDBManager.getGameImage(gameId, type, 'file')
-    }
-  )
+  ipcManager.handle('game:get-media-path', async (_, gameId: string, type: GameMediaType) => {
+    return await GameDBManager.getGameImage(gameId, type, 'file')
+  })
 
-  ipcManager.handle(
-    'game:remove-media',
-    async (_, gameId: string, type: 'cover' | 'background' | 'icon' | 'logo') => {
-      return await GameDBManager.removeGameImage(gameId, type)
-    }
-  )
+  ipcManager.handle('game:remove-media', async (_, gameId: string, type: GameMediaType) => {
+    return await GameDBManager.removeGameImage(gameId, type)
+  })
 
   ipcManager.handle('game:check-exits-by-path', async (_, gamePath: string) => {
     return await GameDBManager.checkGameExitsByPath(gamePath)

--- a/src/main/features/importer/services/versionConverter/common.ts
+++ b/src/main/features/importer/services/versionConverter/common.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_CONFIG_VALUES,
+  GameMediaType,
   gameCollectionDoc,
   gameDoc,
   gameLocalDoc,
@@ -385,7 +386,7 @@ async function convertGame(gameId: string, gamePath: string): Promise<void> {
 }
 
 async function processGameImages(gameId: string, gamePath: string): Promise<void> {
-  const imageTypes = ['background', 'cover', 'icon', 'logo']
+  const imageTypes: GameMediaType[] = ['background', 'cover', 'icon', 'logo', 'wideCover']
   const possibleExtensions = ['webp', 'jpg', 'jpeg', 'png', 'gif', 'ico']
 
   for (const type of imageTypes) {
@@ -399,7 +400,7 @@ async function processGameImages(gameId: string, gamePath: string): Promise<void
       if (exists) {
         try {
           const imageData = await fse.readFile(imagePath)
-          await GameDBManager.setGameImage(gameId, type as any, imageData)
+          await GameDBManager.setGameImage(gameId, type, imageData)
 
           imageFound = true
           console.log(`Processed ${type} image for game ${gameId}`)

--- a/src/main/features/scraper/ipc.ts
+++ b/src/main/features/scraper/ipc.ts
@@ -30,6 +30,13 @@ export function setupScraperIPC(): void {
   )
 
   ipcManager.handle(
+    'scraper:get-game-wide-covers',
+    async (_, dataSource: string, identifier: ScraperIdentifier) => {
+      return await scraperManager.getGameWideCovers(dataSource, identifier)
+    }
+  )
+
+  ipcManager.handle(
     'scraper:get-game-covers',
     async (_, dataSource: string, identifier: ScraperIdentifier) => {
       return await scraperManager.getGameCovers(dataSource, identifier)

--- a/src/main/features/scraper/providers/google/provider.ts
+++ b/src/main/features/scraper/providers/google/provider.ts
@@ -6,6 +6,10 @@ export const googleProvider: ScraperProvider = {
   id: 'google',
   name: 'Google',
 
+  async getGameWideCovers(identifier: ScraperIdentifier): Promise<string[]> {
+    return await searchGameImages(identifier.value, 'hero')
+  },
+
   async getGameBackgrounds(identifier: ScraperIdentifier): Promise<string[]> {
     return await searchGameImages(identifier.value, 'hero')
   },

--- a/src/main/features/scraper/providers/google/provider.ts
+++ b/src/main/features/scraper/providers/google/provider.ts
@@ -1,21 +1,21 @@
-import { ScraperProvider } from '../../services/types'
 import { ScraperIdentifier } from '@appTypes/utils'
 import { searchGameImages } from '~/utils'
+import { ScraperProvider } from '../../services/types'
 
 export const googleProvider: ScraperProvider = {
   id: 'google',
   name: 'Google',
 
   async getGameWideCovers(identifier: ScraperIdentifier): Promise<string[]> {
-    return await searchGameImages(identifier.value, 'hero')
+    return await searchGameImages(identifier.value, ['hero', 'header', 'wallpaper'])
   },
 
   async getGameBackgrounds(identifier: ScraperIdentifier): Promise<string[]> {
-    return await searchGameImages(identifier.value, 'hero')
+    return await searchGameImages(identifier.value, ['wallpaper', 'CG'])
   },
 
   async getGameCovers(identifier: ScraperIdentifier): Promise<string[]> {
-    return await searchGameImages(identifier.value, 'cover')
+    return await searchGameImages(identifier.value, ['cover', 'poster'])
   },
 
   async getGameLogos(identifier: ScraperIdentifier): Promise<string[]> {

--- a/src/main/features/scraper/providers/steam/api.ts
+++ b/src/main/features/scraper/providers/steam/api.ts
@@ -1,16 +1,18 @@
+import { GameList, GameMetadata, ScraperIdentifier } from '@appTypes/utils'
 import {
+  checkSteamGameExists,
+  getGameBackgrounds,
+  getGameBackgroundsByName,
   getGameCover,
   getGameCoverByName,
-  getSteamMetadata,
-  getSteamMetadataByName,
-  checkSteamGameExists,
-  searchSteamGames,
+  getGameHeader,
+  getGameHeaderByName,
   getGameLogo,
   getGameLogoByName,
-  getGameBackgrounds,
-  getGameBackgroundsByName
+  getSteamMetadata,
+  getSteamMetadataByName,
+  searchSteamGames
 } from './common'
-import { GameList, GameMetadata, ScraperIdentifier } from '@appTypes/utils'
 
 export async function searchGamesFromSteam(gameName: string): Promise<GameList> {
   try {
@@ -58,6 +60,19 @@ export async function getGameBackgroundsFromSteam(
     return backgrounds.length > 0 ? backgrounds : []
   } catch (error) {
     console.error('Error fetching game backgrounds:', error)
+    return []
+  }
+}
+
+export async function getGameWideCoversFromSteam(identifier: ScraperIdentifier): Promise<string[]> {
+  try {
+    const wideCover =
+      identifier.type === 'id'
+        ? await getGameHeader(identifier.value)
+        : await getGameHeaderByName(identifier.value)
+    return wideCover ? [wideCover] : []
+  } catch (error) {
+    console.error('Error fetching game wide cover:', error)
     return []
   }
 }

--- a/src/main/features/scraper/providers/steam/common.ts
+++ b/src/main/features/scraper/providers/steam/common.ts
@@ -269,6 +269,18 @@ export async function getGameScreenshots(appId: string): Promise<string[]> {
     : []
 }
 
+export async function getGameHeader(appId: string): Promise<string> {
+  const langConfig = i18next.t('scraper:steam.config', {
+    returnObjects: true
+  }) as SteamLanguageConfig
+
+  const urlLocal = `${STEAM_URLS.STORE}/api/appdetails?appids=${appId}&l=${langConfig.apiLanguageCode || 'english'}`
+  const data = (await fetchSteamAPI(urlLocal)) as SteamAppDetailsResponse
+
+  // Steam appdetails exposes the store header capsule URL as header_image.
+  return data[appId]?.success ? data[appId].data.header_image || '' : ''
+}
+
 export async function getGameBackgrounds(appId: string): Promise<string[]> {
   const heroUrl = await getGameHero(appId)
   const screenshots = await getGameScreenshots(appId)
@@ -359,6 +371,17 @@ export async function getGameBackgroundsByName(gameName: string): Promise<string
   } catch (error) {
     console.error(`Error fetching screenshots for game ${gameName}:`, error)
     return []
+  }
+}
+
+export async function getGameHeaderByName(gameName: string): Promise<string> {
+  try {
+    const games = await searchSteamGames(gameName)
+    if (games.length === 0) return ''
+    return getGameHeader(games[0].id)
+  } catch (error) {
+    console.error(`Error fetching header for game ${gameName}:`, error)
+    return ''
   }
 }
 

--- a/src/main/features/scraper/providers/steam/provider.ts
+++ b/src/main/features/scraper/providers/steam/provider.ts
@@ -5,6 +5,7 @@ import {
   getGameMetadataFromSteam,
   checkGameExistsOnSteam,
   getGameBackgroundsFromSteam,
+  getGameWideCoversFromSteam,
   getGameCoversFromSteam,
   getGameLogosFromSteam
 } from './api'
@@ -36,6 +37,10 @@ export const steamProvider: ScraperProvider = {
 
   async getGameBackgrounds(identifier: ScraperIdentifier): Promise<string[]> {
     return await getGameBackgroundsFromSteam(identifier)
+  },
+
+  async getGameWideCovers(identifier: ScraperIdentifier): Promise<string[]> {
+    return await getGameWideCoversFromSteam(identifier)
   },
 
   async getGameCovers(identifier: ScraperIdentifier): Promise<string[]> {

--- a/src/main/features/scraper/services/ScraperManager.ts
+++ b/src/main/features/scraper/services/ScraperManager.ts
@@ -123,6 +123,25 @@ export class ScraperManager {
     }
   }
 
+  public async getGameWideCovers(
+    providerId: string,
+    identifier: ScraperIdentifier
+  ): Promise<string[]> {
+    try {
+      const provider = this.getProvider(providerId)
+      if (!provider) {
+        throw new Error(`Provider '${providerId}' not found`)
+      }
+      if (!provider.getGameWideCovers) {
+        throw new Error(`Provider '${providerId}' does not support getting game wide covers`)
+      }
+      return provider.getGameWideCovers(identifier)
+    } catch (error) {
+      log.error(`[Scraper] Failed to get game wide covers using provider '${providerId}': ${error}`)
+      return []
+    }
+  }
+
   public async getGameCovers(providerId: string, identifier: ScraperIdentifier): Promise<string[]> {
     try {
       const provider = this.getProvider(providerId)

--- a/src/main/features/scraper/services/types.ts
+++ b/src/main/features/scraper/services/types.ts
@@ -8,6 +8,7 @@ export interface ScraperProvider {
   searchGames?(gameName: string, gamePath?: string): Promise<GameList>
   checkGameExists?(identifier: ScraperIdentifier): Promise<boolean>
   getGameMetadata?(identifier: ScraperIdentifier): Promise<GameMetadata>
+  getGameWideCovers?(identifier: ScraperIdentifier): Promise<string[]>
   getGameBackgrounds?(identifier: ScraperIdentifier): Promise<string[]>
   getGameCovers?(identifier: ScraperIdentifier): Promise<string[]>
   getGameLogos?(identifier: ScraperIdentifier): Promise<string[]>

--- a/src/main/utils/image.ts
+++ b/src/main/utils/image.ts
@@ -11,23 +11,74 @@ const upscalerProcessMutex = new Mutex()
 
 export async function searchGameImages(
   gameName: string,
-  imageType: 'icon' | 'logo' | 'hero' | 'cover' | string,
+  promptTerms: string | string[],
   limit: number = 30
 ): Promise<string[]> {
   try {
-    const imageUrls: string[] = []
+    const normalizedTerms = normalizePromptTerms(promptTerms)
+    const queries =
+      normalizedTerms.length > 0
+        ? normalizedTerms.map((term) => `"${normalizeGoogleSearchTerm(gameName)}" ${term}`)
+        : [`"${normalizeGoogleSearchTerm(gameName)}"`]
 
-    // Using Google Image Search
-    const results = await gis(`"${gameName}" ${imageType === 'hero' ? 'wallpaper' : imageType}`)
-    for (const result of results.slice(0, limit)) {
-      imageUrls.push(result.url || '')
+    const validQueries = queries.filter(Boolean)
+    if (validQueries.length === 0) {
+      return []
     }
 
-    return imageUrls
+    // Google Search officially documents quotes, but we did not find reliable, detailed
+    // Web Search documentation for composing stable mixed boolean expressions such as
+    // AND + OR with parentheses. To avoid relying on brittle query parsing rules, run
+    // one simple query per media hint term and merge the results afterward.
+    const resultsByQuery = await Promise.all(validQueries.map((query) => gis(query)))
+    const rankedUrls: Record<string, { hitCount: number; seenOrder: number }> = {}
+
+    for (const results of resultsByQuery) {
+      let seenOrder = 0
+      for (const result of results.slice(0, limit)) {
+        const url = result.url || ''
+        if (!url) continue
+
+        const existing = rankedUrls[url]
+        if (existing) {
+          existing.hitCount += 1
+          existing.seenOrder = Math.min(existing.seenOrder, seenOrder)
+        } else {
+          rankedUrls[url] = { hitCount: 1, seenOrder: seenOrder }
+        }
+
+        seenOrder += 1
+      }
+    }
+
+    return Object.entries(rankedUrls)
+      .sort(
+        ([_aUrl, aRank], [_bUrl, bRank]) =>
+          bRank.hitCount - aRank.hitCount || aRank.seenOrder - bRank.seenOrder
+      )
+      .slice(0, limit)
+      .map(([url]) => url)
   } catch (error) {
     console.error('Error searching for images:', error)
     return []
   }
+}
+
+function normalizePromptTerms(promptTerms: string | string[]): string[] {
+  const uniqueTerms = new Set<string>()
+
+  for (const term of Array.isArray(promptTerms) ? promptTerms : [promptTerms]) {
+    const normalizedTerm = normalizeGoogleSearchTerm(term)
+    if (!normalizedTerm) continue
+
+    uniqueTerms.add(normalizedTerm)
+  }
+
+  return Array.from(uniqueTerms)
+}
+
+function normalizeGoogleSearchTerm(term: string): string {
+  return term.replace(/"/g, ' ').replace(/\s+/g, ' ').trim()
 }
 
 export async function convertToWebP(

--- a/src/renderer/locales/en/game.json
+++ b/src/renderer/locales/en/game.json
@@ -568,7 +568,12 @@
         "search": {
           "title": "Search Images",
           "dataSource": "Data Source",
-          "searchTitle": "Search Title"
+          "searchTitle": "Search Title",
+          "searchType": "Search Type",
+          "quickFill": "Quick Fill",
+          "byName": "Search by Name",
+          "byId": "Search by ID",
+          "storedId": "Stored ID"
         },
         "url": {
           "empty": "Please enter a link address"
@@ -592,6 +597,7 @@
           "searching": "Searching…",
           "searchSuccess": "Search successful",
           "searchError": "Search failed: {{message}}",
+          "emptySearchValue": "Please enter a search value",
           "noResultsFound": "No images found",
           "selectImage": "Please select an image",
           "cropping": "Cropping…",

--- a/src/renderer/locales/en/game.json
+++ b/src/renderer/locales/en/game.json
@@ -543,13 +543,15 @@
           "icon": "Icon",
           "background": "Background",
           "cover": "Cover",
-          "logo": "Logo"
+          "logo": "Logo",
+          "wideCover": "Wide Cover"
         },
         "empty": {
           "icon": "No icon",
           "background": "No background",
           "cover": "No cover",
           "logo": "No logo",
+          "wideCover": "No wide cover",
           "images": "No images"
         },
         "actions": {

--- a/src/renderer/locales/ja/game.json
+++ b/src/renderer/locales/ja/game.json
@@ -568,7 +568,12 @@
         "search": {
           "title": "画像を検索",
           "dataSource": "データソース",
-          "searchTitle": "検索タイトル"
+          "searchTitle": "検索タイトル",
+          "searchType": "検索方式",
+          "quickFill": "クイック入力",
+          "byName": "名前で検索",
+          "byId": "IDで検索",
+          "storedId": "保存済み ID"
         },
         "url": {
           "empty": "リンクアドレスを入力してください"
@@ -592,6 +597,7 @@
           "searching": "検索中…",
           "searchSuccess": "検索に成功しました",
           "searchError": "検索に失敗しました: {{message}}",
+          "emptySearchValue": "検索内容を入力してください",
           "noResultsFound": "画像が見つかりませんでした",
           "selectImage": "画像を選択してください",
           "cropping": "切り抜き中…",

--- a/src/renderer/locales/ja/game.json
+++ b/src/renderer/locales/ja/game.json
@@ -543,13 +543,15 @@
           "icon": "アイコン",
           "background": "背景",
           "cover": "カバー",
-          "logo": "ロゴ"
+          "logo": "ロゴ",
+          "wideCover": "ワイドカバー"
         },
         "empty": {
           "icon": "アイコンなし",
           "background": "背景なし",
           "cover": "カバーなし",
           "logo": "ロゴなし",
+          "wideCover": "ワイドカバーなし",
           "images": "画像なし"
         },
         "actions": {

--- a/src/renderer/locales/zh-CN/game.json
+++ b/src/renderer/locales/zh-CN/game.json
@@ -568,7 +568,12 @@
         "search": {
           "title": "搜索图片",
           "dataSource": "数据源",
-          "searchTitle": "搜索标题"
+          "searchTitle": "搜索标题",
+          "searchType": "搜索方式",
+          "quickFill": "快速填充",
+          "byName": "按名称搜索",
+          "byId": "按 ID 搜索",
+          "storedId": "已存储 ID"
         },
         "url": {
           "empty": "请输入链接地址"
@@ -592,6 +597,7 @@
           "searching": "搜索中…",
           "searchSuccess": "搜索成功",
           "searchError": "搜索失败: {{message}}",
+          "emptySearchValue": "请输入搜索内容",
           "noResultsFound": "未找到相关图片",
           "selectImage": "请选择一张图片",
           "cropping": "正在裁剪…",

--- a/src/renderer/locales/zh-CN/game.json
+++ b/src/renderer/locales/zh-CN/game.json
@@ -543,13 +543,15 @@
           "icon": "图标",
           "background": "背景",
           "cover": "封面",
-          "logo": "徽标"
+          "logo": "徽标",
+          "wideCover": "宽幅封面"
         },
         "empty": {
           "icon": "暂无图标",
           "background": "暂无背景",
           "cover": "暂无封面",
           "logo": "暂无徽标",
+          "wideCover": "暂无宽幅封面",
           "images": "暂无图片"
         },
         "actions": {

--- a/src/renderer/locales/zh-TW/game.json
+++ b/src/renderer/locales/zh-TW/game.json
@@ -543,13 +543,15 @@
           "icon": "圖示",
           "background": "背景",
           "cover": "封面",
-          "logo": "徽標"
+          "logo": "徽標",
+          "wideCover": "寬幅封面"
         },
         "empty": {
           "icon": "暫無圖示",
           "background": "暫無背景",
           "cover": "暫無封面",
           "logo": "暫無徽標",
+          "wideCover": "暫無寬幅封面",
           "images": "暫無圖片"
         },
         "actions": {

--- a/src/renderer/locales/zh-TW/game.json
+++ b/src/renderer/locales/zh-TW/game.json
@@ -568,7 +568,12 @@
         "search": {
           "title": "搜尋圖片",
           "dataSource": "資料源",
-          "searchTitle": "搜尋標題"
+          "searchTitle": "搜尋標題",
+          "searchType": "搜尋方式",
+          "quickFill": "快速填入",
+          "byName": "按名稱搜尋",
+          "byId": "按 ID 搜尋",
+          "storedId": "已儲存 ID"
         },
         "url": {
           "empty": "請輸入連結地址"
@@ -592,6 +597,7 @@
           "searching": "搜尋中…",
           "searchSuccess": "搜尋成功",
           "searchError": "搜尋失敗: {{message}}",
+          "emptySearchValue": "請輸入搜尋內容",
           "noResultsFound": "未找到相關圖片",
           "selectImage": "請選擇一張圖片",
           "cropping": "正在裁剪…",

--- a/src/renderer/src/components/Game/Config/Properties/Media/SearchMediaDialog.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Media/SearchMediaDialog.tsx
@@ -1,3 +1,4 @@
+import type { GameMediaType } from '@appTypes/models'
 import { ScraperCapabilities } from '@appTypes/utils'
 import { Button } from '@ui/button'
 import { Card } from '@ui/card'
@@ -19,10 +20,9 @@ import { ipcManager } from '~/app/ipc'
 import { useConfigState } from '~/hooks'
 import { cn } from '~/utils'
 
-type MediaType = 'cover' | 'icon' | 'logo' | 'background'
-type DataSourceMap = Record<MediaType, string>
+type DataSourceMap = Record<GameMediaType, string>
 
-function checkMediaCapability(capabilities: ScraperCapabilities[], type: MediaType): boolean {
+function checkMediaCapability(capabilities: ScraperCapabilities[], type: GameMediaType): boolean {
   switch (type) {
     case 'cover':
       return capabilities.includes('getGameCovers')
@@ -32,6 +32,8 @@ function checkMediaCapability(capabilities: ScraperCapabilities[], type: MediaTy
       return capabilities.includes('getGameLogos')
     case 'background':
       return capabilities.includes('getGameBackgrounds')
+    case 'wideCover':
+      return capabilities.includes('getGameWideCovers')
     default:
       return false
   }
@@ -40,7 +42,7 @@ function checkMediaCapability(capabilities: ScraperCapabilities[], type: MediaTy
 interface SearchMediaDialogProps {
   isOpen: boolean
   onClose: () => void
-  type: MediaType
+  type: GameMediaType
   gameTitle: string
   onSelect: (imagePath: string) => void
 }
@@ -58,7 +60,8 @@ export function SearchMediaDialog({
     cover: 'google',
     icon: 'google',
     logo: 'google',
-    background: 'google'
+    background: 'google',
+    wideCover: 'google'
   })
   const [defaultMediaDataSource] = useConfigState('game.scraper.common.defaultMediaDataSource')
   const [availableDataSources, setAvailableDataSources] = useState<
@@ -72,7 +75,13 @@ export function SearchMediaDialog({
     const fetchAvailableDataSources = async (): Promise<void> => {
       const sources = await ipcManager.invoke(
         'scraper:get-provider-infos-with-capabilities',
-        ['getGameCovers', 'getGameIcons', 'getGameLogos', 'getGameBackgrounds'],
+        [
+          'getGameCovers',
+          'getGameIcons',
+          'getGameLogos',
+          'getGameBackgrounds',
+          'getGameWideCovers'
+        ],
         false
       )
       setAvailableDataSources(sources)
@@ -88,10 +97,11 @@ export function SearchMediaDialog({
       cover: 'google',
       icon: 'google',
       logo: 'google',
-      background: 'google'
+      background: 'google',
+      wideCover: 'google'
     }
 
-    for (const t of ['cover', 'icon', 'logo', 'background'] as MediaType[]) {
+    for (const t of ['cover', 'icon', 'logo', 'background', 'wideCover'] as GameMediaType[]) {
       if (checkMediaCapability(defaultSource.capabilities, t)) {
         nextDataSources[t] = defaultMediaDataSource
       }
@@ -137,6 +147,12 @@ export function SearchMediaDialog({
           break
         case 'background':
           result = await ipcManager.invoke('scraper:get-game-backgrounds', dataSources.background, {
+            type: 'name',
+            value: searchTitle
+          })
+          break
+        case 'wideCover':
+          result = await ipcManager.invoke('scraper:get-game-wide-covers', dataSources.wideCover, {
             type: 'name',
             value: searchTitle
           })

--- a/src/renderer/src/components/Game/Config/Properties/Media/SearchMediaDialog.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Media/SearchMediaDialog.tsx
@@ -1,5 +1,5 @@
 import type { GameMediaType } from '@appTypes/models'
-import { ScraperCapabilities } from '@appTypes/utils'
+import type { ScraperCapabilities, ScraperIdentifier } from '@appTypes/utils'
 import { Button } from '@ui/button'
 import { Card } from '@ui/card'
 import { Dialog, DialogContent } from '@ui/dialog'
@@ -21,6 +21,21 @@ import { useConfigState } from '~/hooks'
 import { cn } from '~/utils'
 
 type DataSourceMap = Record<GameMediaType, string>
+type SearchMode = ScraperIdentifier['type']
+type SearchPresetValue = 'originalName' | 'name' | 'storedId'
+
+interface SearchPresetOption {
+  value: SearchPresetValue
+  label: string
+  searchMode: SearchMode
+  searchValue: string
+}
+
+interface MediaSearchContext {
+  name: string
+  originalName: string
+  storedIds: Partial<Record<string, string>>
+}
 
 function checkMediaCapability(capabilities: ScraperCapabilities[], type: GameMediaType): boolean {
   switch (type) {
@@ -43,7 +58,7 @@ interface SearchMediaDialogProps {
   isOpen: boolean
   onClose: () => void
   type: GameMediaType
-  gameTitle: string
+  searchContext: MediaSearchContext
   onSelect: (imagePath: string) => void
 }
 
@@ -51,11 +66,12 @@ export function SearchMediaDialog({
   isOpen,
   onClose,
   type,
-  gameTitle,
+  searchContext,
   onSelect
 }: SearchMediaDialogProps): React.JSX.Element {
   const { t } = useTranslation('game')
-  const [searchTitle, setSearchTitle] = useState(gameTitle)
+  const [searchTitle, setSearchTitle] = useState('')
+  const [searchMode, setSearchMode] = useState<SearchMode>('name')
   const [dataSources, setDataSources] = useState<DataSourceMap>({
     cover: 'google',
     icon: 'google',
@@ -70,6 +86,8 @@ export function SearchMediaDialog({
   const [imageList, setImageList] = useState<string[]>([])
   const [selectedImage, setSelectedImage] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const currentDataSource = dataSources[type]
+  const quickFillOptions = getSearchPresetOptions(currentDataSource, searchContext, t)
 
   useEffect(() => {
     const fetchAvailableDataSources = async (): Promise<void> => {
@@ -111,51 +129,55 @@ export function SearchMediaDialog({
 
   useEffect(() => {
     if (isOpen) {
-      toast.promise(handleSearch(), {
-        loading: t('detail.properties.media.notifications.searching'),
-        success: t('detail.properties.media.notifications.searchSuccess'),
-        error: (err) =>
-          t('detail.properties.media.notifications.searchError', { message: err.message })
-      })
+      const defaultSearchState = getDefaultSearchState(searchContext)
+      setSearchTitle(defaultSearchState.searchValue)
+      setSearchMode(defaultSearchState.searchMode)
+      setImageList([])
+      setSelectedImage('')
     }
   }, [isOpen])
 
-  async function handleSearch(): Promise<void> {
+  async function handleSearch(
+    value: string = searchTitle,
+    mode: SearchMode = searchMode
+  ): Promise<void> {
     if (isLoading) return
+    const normalizedValue = value.trim()
+    if (!normalizedValue) {
+      toast.error(t('detail.properties.media.notifications.emptySearchValue'))
+      return
+    }
     setIsLoading(true)
 
     try {
+      const identifier: ScraperIdentifier = {
+        type: mode,
+        value: normalizedValue
+      }
       let result: string[] = []
       switch (type) {
         case 'cover':
-          result = await ipcManager.invoke('scraper:get-game-covers', dataSources.cover, {
-            type: 'name',
-            value: searchTitle
-          })
+          result = await ipcManager.invoke('scraper:get-game-covers', dataSources.cover, identifier)
           break
         case 'icon':
-          result = await ipcManager.invoke('scraper:get-game-icons', dataSources.icon, {
-            type: 'name',
-            value: searchTitle
-          })
+          result = await ipcManager.invoke('scraper:get-game-icons', dataSources.icon, identifier)
           break
         case 'logo':
-          result = await ipcManager.invoke('scraper:get-game-logos', dataSources.logo, {
-            type: 'name',
-            value: searchTitle
-          })
+          result = await ipcManager.invoke('scraper:get-game-logos', dataSources.logo, identifier)
           break
         case 'background':
-          result = await ipcManager.invoke('scraper:get-game-backgrounds', dataSources.background, {
-            type: 'name',
-            value: searchTitle
-          })
+          result = await ipcManager.invoke(
+            'scraper:get-game-backgrounds',
+            dataSources.background,
+            identifier
+          )
           break
         case 'wideCover':
-          result = await ipcManager.invoke('scraper:get-game-wide-covers', dataSources.wideCover, {
-            type: 'name',
-            value: searchTitle
-          })
+          result = await ipcManager.invoke(
+            'scraper:get-game-wide-covers',
+            dataSources.wideCover,
+            identifier
+          )
           break
       }
 
@@ -172,6 +194,31 @@ export function SearchMediaDialog({
     } finally {
       setIsLoading(false)
     }
+  }
+
+  function runSearchWithToast(value: string = searchTitle, mode: SearchMode = searchMode): void {
+    if (isLoading) return
+
+    const normalizedValue = value.trim()
+    if (!normalizedValue) {
+      toast.error(t('detail.properties.media.notifications.emptySearchValue'))
+      return
+    }
+
+    toast.promise(handleSearch(normalizedValue, mode), {
+      loading: t('detail.properties.media.notifications.searching'),
+      success: t('detail.properties.media.notifications.searchSuccess'),
+      error: (err) =>
+        t('detail.properties.media.notifications.searchError', { message: err.message })
+    })
+  }
+
+  function handleSearchPresetChange(value: SearchPresetValue): void {
+    const selectedPreset = quickFillOptions.find((option) => option.value === value)
+    if (!selectedPreset) return
+
+    setSearchTitle(selectedPreset.searchValue)
+    setSearchMode(selectedPreset.searchMode)
   }
 
   function handleConfirm(): void {
@@ -224,55 +271,152 @@ export function SearchMediaDialog({
         </Card>
         {/* Data Source and Search */}
         <Card className={cn('p-3')}>
-          <div className={cn('flex flex-row gap-3')}>
-            <Select
-              value={dataSources[type]}
-              onValueChange={(value) => setDataSources((prev) => ({ ...prev, [type]: value }))}
-            >
-              <SelectTrigger className={cn('w-72')}>
-                <SelectValue placeholder={t('detail.properties.media.search.dataSource')} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectLabel>{t('detail.properties.media.search.dataSource')}</SelectLabel>
-                  {availableDataSources
-                    .filter((source) => checkMediaCapability(source.capabilities, type))
-                    .map((source) => (
-                      <SelectItem key={source.id} value={source.id}>
-                        {source.name}
+          <div className={cn('flex flex-col gap-3')}>
+            <div className={cn('flex flex-row gap-3')}>
+              <Select
+                value={currentDataSource}
+                onValueChange={(value) => setDataSources((prev) => ({ ...prev, [type]: value }))}
+              >
+                <SelectTrigger className={cn('w-72')}>
+                  <SelectValue placeholder={t('detail.properties.media.search.dataSource')} />
+                </SelectTrigger>
+                <SelectContent side="top">
+                  <SelectGroup>
+                    <SelectLabel>{t('detail.properties.media.search.dataSource')}</SelectLabel>
+                    {availableDataSources
+                      .filter((source) => checkMediaCapability(source.capabilities, type))
+                      .map((source) => (
+                        <SelectItem key={source.id} value={source.id}>
+                          {source.name}
+                        </SelectItem>
+                      ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              <Select
+                value={searchMode}
+                onValueChange={(value) => setSearchMode(value as SearchMode)}
+              >
+                <SelectTrigger className={cn('w-48')}>
+                  <SelectValue placeholder={t('detail.properties.media.search.searchType')} />
+                </SelectTrigger>
+                <SelectContent side="top">
+                  <SelectGroup>
+                    <SelectLabel>{t('detail.properties.media.search.searchType')}</SelectLabel>
+                    <SelectItem value="name">
+                      {t('detail.properties.media.search.byName')}
+                    </SelectItem>
+                    <SelectItem value="id">{t('detail.properties.media.search.byId')}</SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+              <Select
+                value=""
+                onValueChange={(value) => handleSearchPresetChange(value as SearchPresetValue)}
+              >
+                <SelectTrigger className={cn('w-48')}>
+                  <SelectValue placeholder={t('detail.properties.media.search.quickFill')} />
+                </SelectTrigger>
+                <SelectContent side="top">
+                  <SelectGroup>
+                    <SelectLabel>{t('detail.properties.media.search.quickFill')}</SelectLabel>
+                    {quickFillOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
                       </SelectItem>
                     ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-            <Input
-              value={searchTitle}
-              onChange={(e) => setSearchTitle(e.target.value)}
-              placeholder={t('detail.properties.media.search.searchTitle')}
-              className={cn('')}
-            />
-            <Button
-              onClick={() => {
-                toast.promise(handleSearch(), {
-                  loading: t('detail.properties.media.notifications.searching'),
-                  success: t('detail.properties.media.notifications.searchSuccess'),
-                  error: (err) =>
-                    t('detail.properties.media.notifications.searchError', { message: err.message })
-                })
-              }}
-              size={'icon'}
-              className={cn('shrink-0')}
-              disabled={isLoading}
-            >
-              <span className={cn('icon-[mdi--magnify] w-[20px] h-[20px]')}></span>
-            </Button>
-            <Button onClick={handleConfirm}>{t('utils:common.confirm')}</Button>
-            <Button variant="outline" onClick={handleClose}>
-              {t('utils:common.cancel')}
-            </Button>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className={cn('flex flex-row gap-3')}>
+              <Input
+                value={searchTitle}
+                onChange={(e) => setSearchTitle(e.target.value)}
+                placeholder={t('detail.properties.media.search.searchTitle')}
+                className={cn('flex-1')}
+              />
+              <Button
+                onClick={() => runSearchWithToast()}
+                size={'icon'}
+                className={cn('shrink-0')}
+                disabled={isLoading}
+              >
+                <span className={cn('icon-[mdi--magnify] w-[20px] h-[20px]')}></span>
+              </Button>
+              <Button onClick={handleConfirm}>{t('utils:common.confirm')}</Button>
+              <Button variant="outline" onClick={handleClose}>
+                {t('utils:common.cancel')}
+              </Button>
+            </div>
           </div>
         </Card>
       </DialogContent>
     </Dialog>
   )
+}
+
+function getDefaultSearchState(searchContext: MediaSearchContext): {
+  searchValue: string
+  searchMode: SearchMode
+} {
+  const originalName = searchContext.originalName.trim()
+  if (originalName) {
+    return {
+      searchValue: originalName,
+      searchMode: 'name'
+    }
+  }
+
+  const localizedName = searchContext.name.trim()
+  if (localizedName) {
+    return {
+      searchValue: localizedName,
+      searchMode: 'name'
+    }
+  }
+
+  return {
+    searchValue: '',
+    searchMode: 'name'
+  }
+}
+
+function getSearchPresetOptions(
+  dataSource: string,
+  searchContext: MediaSearchContext,
+  t: (key: string) => string
+): SearchPresetOption[] {
+  const options: SearchPresetOption[] = []
+  const originalName = searchContext.originalName.trim()
+  if (originalName) {
+    options.push({
+      value: 'originalName',
+      label: t('detail.overview.information.fields.originalName'),
+      searchMode: 'name',
+      searchValue: originalName
+    })
+  }
+
+  const localizedName = searchContext.name.trim()
+  if (localizedName) {
+    options.push({
+      value: 'name',
+      label: t('detail.overview.information.fields.localizedName'),
+      searchMode: 'name',
+      searchValue: localizedName
+    })
+  }
+
+  const storedId = searchContext.storedIds[dataSource]?.trim()
+  if (storedId) {
+    options.push({
+      value: 'storedId',
+      label: t('detail.properties.media.search.storedId'),
+      searchMode: 'id',
+      searchValue: storedId
+    })
+  }
+
+  return options
 }

--- a/src/renderer/src/components/Game/Config/Properties/Media/UrlDialog.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Media/UrlDialog.tsx
@@ -1,10 +1,11 @@
-import { cn } from '~/utils'
-import { Button } from '~/components/ui/button'
-import { Dialog, DialogContent, DialogTrigger } from '~/components/ui/dialog'
-import { Input } from '~/components/ui/input'
+import type { GameMediaType } from '@appTypes/models'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import { Button } from '~/components/ui/button'
+import { Dialog, DialogContent, DialogTrigger } from '~/components/ui/dialog'
+import { Input } from '~/components/ui/input'
+import { cn } from '~/utils'
 
 export function UrlDialog({
   setMediaWithUrl,
@@ -12,15 +13,10 @@ export function UrlDialog({
   setIsUrlDialogOpen,
   type
 }: {
-  setMediaWithUrl: (type: 'cover' | 'background' | 'icon' | 'logo', URL: string) => void
-  isUrlDialogOpen: { icon: boolean; cover: boolean; background: boolean; logo: boolean }
-  setIsUrlDialogOpen: (isOpen: {
-    icon: boolean
-    cover: boolean
-    background: boolean
-    logo: boolean
-  }) => void
-  type: 'cover' | 'background' | 'icon' | 'logo'
+  setMediaWithUrl: (type: GameMediaType, URL: string) => void
+  isUrlDialogOpen: Record<GameMediaType, boolean>
+  setIsUrlDialogOpen: (isOpen: Record<GameMediaType, boolean>) => void
+  type: GameMediaType
 }): React.JSX.Element {
   const { t } = useTranslation('game')
   const [mediaUrl, setMediaUrl] = useState<string>('')

--- a/src/renderer/src/components/Game/Config/Properties/Media/main.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Media/main.tsx
@@ -1,3 +1,4 @@
+import type { GameMediaType } from '@appTypes/models'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -15,21 +16,30 @@ import { CropDialog } from './CropDialog'
 import { SearchMediaDialog } from './SearchMediaDialog'
 import { UrlDialog } from './UrlDialog'
 
+const MEDIA_CARD_CONFIGS: Array<{ type: GameMediaType; aspectRatio: string }> = [
+  { type: 'cover', aspectRatio: '2/3' },
+  { type: 'background', aspectRatio: '2' },
+  { type: 'icon', aspectRatio: '1' },
+  { type: 'logo', aspectRatio: '3/2' },
+  { type: 'wideCover', aspectRatio: '3/2' }
+]
+
 export function Media({ gameId }: { gameId: string }): React.JSX.Element {
   const { t } = useTranslation('game')
   const refreshLight = useLightStore((state) => state.refresh)
   const openImageViewerDialog = useGameDetailStore((state) => state.openImageViewerDialog)
 
-  const [isUrlDialogOpen, setIsUrlDialogOpen] = useState({
+  const [isUrlDialogOpen, setIsUrlDialogOpen] = useState<Record<GameMediaType, boolean>>({
     icon: false,
     cover: false,
     background: false,
-    logo: false
+    logo: false,
+    wideCover: false
   })
 
   const [cropDialogState, setCropDialogState] = useState<{
     isOpen: boolean
-    type: 'cover' | 'background' | 'icon' | 'logo'
+    type: GameMediaType
     imagePath: string | null
     isResizing: boolean
   }>({
@@ -40,11 +50,11 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
   })
 
   const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false)
-  const [searchType, setSearchType] = useState<'cover' | 'background' | 'icon' | 'logo'>('cover')
+  const [searchType, setSearchType] = useState<GameMediaType>('cover')
 
   const [originalName] = useGameState(gameId, 'metadata.originalName')
 
-  async function handleFileSelect(type: 'cover' | 'background' | 'icon' | 'logo'): Promise<void> {
+  async function handleFileSelect(type: GameMediaType): Promise<void> {
     try {
       const filePath = await ipcManager.invoke('system:select-path-dialog', ['openFile'])
       if (!filePath) return
@@ -66,9 +76,7 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
     }
   }
 
-  async function handleClipboardImport(
-    type: 'cover' | 'background' | 'icon' | 'logo'
-  ): Promise<void> {
+  async function handleClipboardImport(type: GameMediaType): Promise<void> {
     try {
       const filePath = await ipcManager.invoke('utils:save-clipboard-image')
       if (!filePath) {
@@ -87,7 +95,7 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
     }
   }
 
-  async function handleResize(type: 'cover' | 'background' | 'icon' | 'logo'): Promise<void> {
+  async function handleResize(type: GameMediaType): Promise<void> {
     try {
       // Get current image path
       const currentPath = await ipcManager.invoke('game:get-media-path', gameId, type)
@@ -107,7 +115,7 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
     }
   }
 
-  function setMediaWithUrl(type: 'cover' | 'background' | 'icon' | 'logo', URL: string): void {
+  function setMediaWithUrl(type: GameMediaType, URL: string): void {
     toast.promise(
       async () => {
         setIsUrlDialogOpen({ ...isUrlDialogOpen, [type]: false })
@@ -130,10 +138,7 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
     )
   }
 
-  async function handleCropComplete(
-    type: 'cover' | 'background' | 'icon' | 'logo',
-    filePath: string
-  ): Promise<void> {
+  async function handleCropComplete(type: GameMediaType, filePath: string): Promise<void> {
     setCropDialogState({ isOpen: false, type: 'cover', imagePath: null, isResizing: false })
 
     const action = cropDialogState.isResizing
@@ -164,7 +169,7 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
     )
   }
 
-  async function handleDeleteMedia(type: 'cover' | 'background' | 'icon' | 'logo'): Promise<void> {
+  async function handleDeleteMedia(type: GameMediaType): Promise<void> {
     toast.promise(
       async () => {
         await ipcManager.invoke('game:remove-media', gameId, type)
@@ -186,11 +191,7 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
     )
   }
 
-  const MediaControls = ({
-    type
-  }: {
-    type: 'cover' | 'background' | 'icon' | 'logo'
-  }): React.JSX.Element => (
+  const MediaControls = ({ type }: { type: GameMediaType }): React.JSX.Element => (
     <div className={cn('flex flex-row gap-2')}>
       <Tooltip>
         <TooltipTrigger>
@@ -305,7 +306,7 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
     type,
     aspectRatio
   }: {
-    type: 'cover' | 'background' | 'icon' | 'logo'
+    type: GameMediaType
     aspectRatio: string
   }): React.JSX.Element => (
     <Card className="h-full flex flex-col">
@@ -332,10 +333,9 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
 
   return (
     <div className={cn('grid grid-cols-[1fr_1.5fr] gap-3 w-full h-full')}>
-      <MediaCard type="cover" aspectRatio="2/3" />
-      <MediaCard type="background" aspectRatio="2" />
-      <MediaCard type="icon" aspectRatio="1" />
-      <MediaCard type="logo" aspectRatio="3/2" />
+      {MEDIA_CARD_CONFIGS.map(({ type, aspectRatio }) => (
+        <MediaCard key={type} type={type} aspectRatio={aspectRatio} />
+      ))}
 
       <CropDialog
         isOpen={cropDialogState.isOpen}

--- a/src/renderer/src/components/Game/Config/Properties/Media/main.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Media/main.tsx
@@ -46,6 +46,12 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
 
   const [originalName] = useGameState(gameId, 'metadata.originalName')
 
+  const [name] = useGameState(gameId, 'metadata.name')
+  const [steamId] = useGameState(gameId, 'metadata.steamId')
+  const [vndbId] = useGameState(gameId, 'metadata.vndbId')
+  const [igdbId] = useGameState(gameId, 'metadata.igdbId')
+  const [ymgalId] = useGameState(gameId, 'metadata.ymgalId')
+
   async function handleFileSelect(type: GameMediaType): Promise<void> {
     try {
       const filePath = await ipcManager.invoke('system:select-path-dialog', ['openFile'])
@@ -353,7 +359,17 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
         isOpen={isSearchDialogOpen}
         onClose={() => setIsSearchDialogOpen(false)}
         type={searchType}
-        gameTitle={originalName}
+        searchContext={{
+          name,
+          originalName,
+          storedIds: {
+            steam: steamId,
+            steamgriddb: steamId,
+            vndb: vndbId,
+            igdb: igdbId,
+            ymgal: ymgalId
+          }
+        }}
         onSelect={async (imagePath) => {
           toast.loading(t('detail.properties.media.notifications.downloading'), {
             id: 'download-image-toast'

--- a/src/renderer/src/components/Game/Config/Properties/Media/main.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Media/main.tsx
@@ -16,14 +16,6 @@ import { CropDialog } from './CropDialog'
 import { SearchMediaDialog } from './SearchMediaDialog'
 import { UrlDialog } from './UrlDialog'
 
-const MEDIA_CARD_CONFIGS: Array<{ type: GameMediaType; aspectRatio: string }> = [
-  { type: 'cover', aspectRatio: '2/3' },
-  { type: 'background', aspectRatio: '2' },
-  { type: 'icon', aspectRatio: '1' },
-  { type: 'logo', aspectRatio: '3/2' },
-  { type: 'wideCover', aspectRatio: '3/2' }
-]
-
 export function Media({ gameId }: { gameId: string }): React.JSX.Element {
   const { t } = useTranslation('game')
   const refreshLight = useLightStore((state) => state.refresh)
@@ -304,28 +296,38 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
 
   const MediaCard = ({
     type,
-    aspectRatio
+    previewHeightVh,
+    spanTwoColumns
   }: {
     type: GameMediaType
-    aspectRatio: string
+    previewHeightVh: number
+    spanTwoColumns?: boolean
   }): React.JSX.Element => (
-    <Card className="h-full flex flex-col">
+    <Card className={cn('flex flex-col', spanTwoColumns && 'col-span-2')}>
       <CardHeader>
         <CardTitle>{t(`detail.properties.media.types.${type}`)}</CardTitle>
       </CardHeader>
-      <CardContent className={cn('-mt-2 flex-1 flex flex-col')}>
-        <div className={cn('flex flex-col gap-2 h-full')}>
-          <MediaControls type={type} />
-          <div className={cn('flex-1 flex items-center justify-center')}>
-            <GameImage
-              gameId={gameId}
-              type={type}
-              className={cn(
-                `aspect-[${aspectRatio}] object-${type === 'logo' ? 'contain' : 'cover'} h-auto max-h-full`
-              )}
-              fallback={<div>{t(`detail.properties.media.empty.${type}`)}</div>}
-            />
-          </div>
+      <CardContent className={cn('-mt-2 flex flex-col gap-2')}>
+        <MediaControls type={type} />
+        <div
+          className={cn(
+            'flex w-full items-center justify-center overflow-hidden rounded-md border bg-muted/15 p-2'
+          )}
+          style={{
+            height: `${previewHeightVh}vh`
+          }}
+        >
+          <GameImage
+            gameId={gameId}
+            type={type}
+            fit="contain"
+            className={cn('h-full w-full rounded-md')}
+            fallback={
+              <div className={cn('flex h-full w-full items-center justify-center text-center')}>
+                {t(`detail.properties.media.empty.${type}`)}
+              </div>
+            }
+          />
         </div>
       </CardContent>
     </Card>
@@ -333,9 +335,11 @@ export function Media({ gameId }: { gameId: string }): React.JSX.Element {
 
   return (
     <div className={cn('grid grid-cols-[1fr_1.5fr] gap-3 w-full h-full')}>
-      {MEDIA_CARD_CONFIGS.map(({ type, aspectRatio }) => (
-        <MediaCard key={type} type={type} aspectRatio={aspectRatio} />
-      ))}
+      <MediaCard type="cover" previewHeightVh={40} />
+      <MediaCard type="background" previewHeightVh={40} />
+      <MediaCard type="icon" previewHeightVh={20} />
+      <MediaCard type="logo" previewHeightVh={20} />
+      <MediaCard type="wideCover" previewHeightVh={40} spanTwoColumns />
 
       <CropDialog
         isOpen={cropDialogState.isOpen}

--- a/src/renderer/src/components/Game/utils.ts
+++ b/src/renderer/src/components/Game/utils.ts
@@ -1,8 +1,7 @@
+import type { GameMediaType } from '@appTypes/models'
 import i18next from 'i18next'
 import { toast } from 'sonner'
 import { ipcManager } from '~/app/ipc'
-
-type GameMediaType = 'cover' | 'background' | 'icon' | 'logo'
 
 type OpenImageViewerDialog = (imagePath: string) => void
 

--- a/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
@@ -138,6 +138,7 @@ export function BigGamePoster({
                   onClick={handleGameClick}
                   gameId={gameId}
                   type="wideCover"
+                  forceSmartCrop
                   blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
                   initialMask={true}
                   blurType="bigposter"
@@ -147,6 +148,7 @@ export function BigGamePoster({
                       onClick={handleGameClick}
                       gameId={gameId}
                       type="background"
+                      forceSmartCrop
                       blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
                       initialMask={true}
                       blurType="bigposter"

--- a/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
+++ b/src/renderer/src/components/Showcase/posters/BigGamePoster.tsx
@@ -49,6 +49,20 @@ export function BigGamePoster({
   const stringToBase64 = (str: string): string =>
     btoa(String.fromCharCode(...new TextEncoder().encode(str)))
   const obfuscatedName = stringToBase64(name).slice(0, name.length)
+  const posterImageClassName = cn(
+    'h-[222px] aspect-[3/2] cursor-pointer select-none object-cover rounded-lg bg-accent/30',
+    className
+  )
+  const titleFallback = (
+    <div
+      className={cn(
+        'w-[333px] aspect-[3/2] cursor-pointer object-cover flex items-center justify-center font-bold bg-muted/50',
+        className
+      )}
+    >
+      {gameName}
+    </div>
+  )
 
   // Batch selection state
   const {
@@ -123,23 +137,22 @@ export function BigGamePoster({
                 <GameImage
                   onClick={handleGameClick}
                   gameId={gameId}
-                  type="background"
+                  type="wideCover"
                   blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
                   initialMask={true}
                   blurType="bigposter"
-                  className={cn(
-                    'h-[222px] aspect-[3/2] cursor-pointer select-none object-cover rounded-lg bg-accent/30',
-                    className
-                  )}
+                  className={posterImageClassName}
                   fallback={
-                    <div
-                      className={cn(
-                        'w-[333px] aspect-[3/2] cursor-pointer object-cover flex items-center justify-center font-bold bg-muted/50',
-                        className
-                      )}
-                    >
-                      {gameName}
-                    </div>
+                    <GameImage
+                      onClick={handleGameClick}
+                      gameId={gameId}
+                      type="background"
+                      blur={nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage}
+                      initialMask={true}
+                      blurType="bigposter"
+                      className={posterImageClassName}
+                      fallback={titleFallback}
+                    />
                   }
                 />
               </HoverCardAnimation>

--- a/src/renderer/src/components/ui/game-image.tsx
+++ b/src/renderer/src/components/ui/game-image.tsx
@@ -8,6 +8,7 @@ interface GameImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'
   type: 'background' | 'cover' | 'icon' | 'logo' | string
   onUpdated?: () => void
   fallback?: React.ReactNode
+  fit?: 'cover' | 'contain'
   forceSmartCrop?: boolean
   shadow?: boolean
   flips?: boolean
@@ -23,6 +24,7 @@ export const GameImage: React.FC<GameImageProps> = ({
   onError,
   onUpdated,
   fallback = <div>No Pictures</div>,
+  fit = 'cover',
   forceSmartCrop = false,
   shadow = false,
   flips = false,
@@ -66,7 +68,7 @@ export const GameImage: React.FC<GameImageProps> = ({
 
   const smartCrop = async (): Promise<void> => {
     const img = imgRef.current
-    if (img && (type === 'cover' || forceSmartCrop)) {
+    if (img && fit === 'cover' && (forceSmartCrop || type === 'cover')) {
       // bigPoster in recent games also need smart crop
       try {
         await img.decode?.()
@@ -125,7 +127,7 @@ export const GameImage: React.FC<GameImageProps> = ({
           className
         )}
         style={{
-          objectFit: 'cover',
+          objectFit: fit,
           objectPosition
         }}
         // loading="lazy"

--- a/src/renderer/src/components/ui/game-image.tsx
+++ b/src/renderer/src/components/ui/game-image.tsx
@@ -8,6 +8,7 @@ interface GameImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'
   type: 'background' | 'cover' | 'icon' | 'logo' | string
   onUpdated?: () => void
   fallback?: React.ReactNode
+  forceSmartCrop?: boolean
   shadow?: boolean
   flips?: boolean
   blur?: boolean
@@ -22,6 +23,7 @@ export const GameImage: React.FC<GameImageProps> = ({
   onError,
   onUpdated,
   fallback = <div>No Pictures</div>,
+  forceSmartCrop = false,
   shadow = false,
   flips = false,
   blur = false,
@@ -64,7 +66,8 @@ export const GameImage: React.FC<GameImageProps> = ({
 
   const smartCrop = async (): Promise<void> => {
     const img = imgRef.current
-    if (img && type === 'cover') {
+    if (img && (type === 'cover' || forceSmartCrop)) {
+      // bigPoster in recent games also need smart crop
       try {
         await img.decode?.()
 

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -8,6 +8,7 @@ import {
 import { PosterRenderArgs, RenderResponse, TemplatePayloads } from '@appTypes/poster'
 import { BatchUpdateGameMetadataProgress, OverallScanProgress } from '@appTypes/utils'
 import { ProgressInfo, UpdateCheckResult } from 'electron-updater'
+import type { GameMediaType } from './models'
 import { BatchGameInfo, configDocs, configLocalDocs, gameDoc, GameTimerStatus } from './models'
 import {
   PluginConfiguration,
@@ -170,16 +171,9 @@ type MainIpcEvents =
       'game:update-memory-cover': (gameId: string, memoryId: string, imgPath: string) => void
 
       // Game media management events
-      'game:set-image': (
-        gameId: string,
-        type: 'background' | 'cover' | 'logo' | 'icon',
-        image: string
-      ) => void
-      'game:get-media-path': (
-        gameId: string,
-        type: 'cover' | 'background' | 'icon' | 'logo'
-      ) => string | null
-      'game:remove-media': (gameId: string, type: 'cover' | 'background' | 'icon' | 'logo') => void
+      'game:set-image': (gameId: string, type: GameMediaType, image: string) => void
+      'game:get-media-path': (gameId: string, type: GameMediaType) => string | null
+      'game:remove-media': (gameId: string, type: GameMediaType) => void
       'game:get-memory-cover-path': (gameId: string, memoryId: string) => string | null
       'game:get-memory-masonry-items': (
         gameId: string,
@@ -254,6 +248,10 @@ type MainIpcEvents =
         identifier: ScraperIdentifier
       ) => GameMetadata
       'scraper:get-game-backgrounds': (
+        dataSource: string,
+        identifier: ScraperIdentifier
+      ) => string[]
+      'scraper:get-game-wide-covers': (
         dataSource: string,
         identifier: ScraperIdentifier
       ) => string[]

--- a/src/types/models/game.ts
+++ b/src/types/models/game.ts
@@ -1,5 +1,7 @@
 import { Paths } from 'type-fest'
 
+export type GameMediaType = 'cover' | 'background' | 'icon' | 'logo' | 'wideCover'
+
 export type gameDocs = {
   [gameId: string]: gameDoc
 }

--- a/src/types/utils/scraper.ts
+++ b/src/types/utils/scraper.ts
@@ -93,6 +93,7 @@ export type ScraperCapabilities =
   | 'searchGames'
   | 'checkGameExists'
   | 'getGameMetadata'
+  | 'getGameWideCovers'
   | 'getGameBackgrounds'
   | 'getGameCovers'
   | 'getGameLogos'


### PR DESCRIPTION
## 新增宽幅封面资源

- 新增宽幅封面媒体资源，用于最近游戏大号海报的优先展示选项
- 修复了大号海报未应用智能裁剪的问题
- 支持从steam源刮削宽幅封面

Resolve #599

## 优化媒体属性窗口

- 优化了媒体属性窗口中的展示样式
- 优化了Google图片搜索的提示词
- 支持媒体搜索窗口按ID搜索，支持快速填充游戏名称、ID
- 取消了媒体搜索窗口的打开自动搜索，因其对于这种需要多次手动调整参数的情形适用性偏低