### PR TITLE
fix: remove aggressive GPU hints from poster hover animation

### DIFF
--- a/src/renderer/src/components/animations/HoverCard.tsx
+++ b/src/renderer/src/components/animations/HoverCard.tsx
@@ -91,19 +91,13 @@ export function HoverCardAnimation({
   return (
     <animated.div
       ref={cardRef}
-      className={cn(
-        'relative overflow-hidden rounded-lg',
-        'transform-gpu',
-        'will-change-transform',
-        className
-      )}
+      className={cn('relative overflow-hidden rounded-lg', className)}
       {...rest}
     >
       {/* Image layer */}
       <animated.div
         style={{
           transform: springs.imageScale.to((s) => `scale(${s})`),
-          willChange: 'transform',
           width: '100%',
           height: '100%'
         }}


### PR DESCRIPTION
在原先的游戏海报动画组件中，使用了 `transform-gpu` 和 `will-change-transform` 来提升悬浮动画的渲染性能，但这套优化策略在高密度海报场景下过于激进。尤其是在评分报告这类会同时挂载大量封面的页面中，如果设备 GPU 性能较弱，这些持续性的 GPU 渲染提示会显著增加合成与渲染压力，严重时甚至可能导致页面渲染卡死。

本次提交移除了这部分过度激进的优化，将相关渲染决策重新交由浏览器自动处理，在保留原有动画效果的同时，规避此前出现的卡死问题。

Fix #598 