### PR TITLE
fix: handle deferred game loading when the local-game filter is enabled

### DIFF
--- a/src/renderer/src/stores/game/gameLocalStoreFactory.ts
+++ b/src/renderer/src/stores/game/gameLocalStoreFactory.ts
@@ -83,7 +83,12 @@ export function getGameLocalStore(gameId: string): GameLocalStore {
 /**
  * Batch initialize game local store
  */
-export function initializeGameLocalStores(documents: Record<string, gameLocalDoc>): void {
+export async function initializeGameLocalStores(
+  documents: Record<string, gameLocalDoc>,
+  options?: {
+    awaitPathValidity?: boolean
+  }
+): Promise<void> {
   Object.entries(documents).forEach(([gameId, gameData]) => {
     const store = getGameLocalStore(gameId)
     store.getState().initialize(gameData)
@@ -93,7 +98,11 @@ export function initializeGameLocalStores(documents: Record<string, gameLocalDoc
     .map((doc) => doc.path?.gamePath)
     .filter((p): p is string => !!p)
   useGamePathStore.getState().addPaths(gamePaths)
-  useGamePathStore.getState().verifyAll()
+
+  const verifyPromise = useGamePathStore.getState().verifyAll()
+  if (options?.awaitPathValidity) {
+    await verifyPromise
+  }
 }
 
 export function deleteGameLocalStore(gameId: string): void {

--- a/src/renderer/src/stores/sync.ts
+++ b/src/renderer/src/stores/sync.ts
@@ -16,7 +16,8 @@ import {
   AttachmentChange,
   gameDocs,
   gameLocalDocs,
-  gameCollectionDocs
+  gameCollectionDocs,
+  LocalGameFilterMode
 } from '@appTypes/models'
 import { isEqual } from 'lodash'
 
@@ -37,7 +38,16 @@ const DB_INITIALIZERS: Record<string, (data: any) => Promise<void>> = {
     console.log(`[DB] game: initialized ${Object.keys(data).length} game store`)
   },
   'game-local': async (data: gameLocalDocs): Promise<void> => {
-    initializeGameLocalStores(data)
+    const localGameFilterMode = useConfigStore
+      .getState()
+      .getConfigValue('appearances.localGameFilterMode')
+
+    await initializeGameLocalStores(data, {
+      // When the initial view filters by local availability, wait for path checks
+      // before marking games as ready; otherwise the first render treats every
+      // `valid: null` path as non-local and the UI stays empty.
+      awaitPathValidity: localGameFilterMode !== LocalGameFilterMode.All
+    })
     console.log(`[DB] game-local: initialized ${Object.keys(data).length} game-local store`)
   },
   'game-collection': async (data: gameCollectionDocs): Promise<void> => {


### PR DESCRIPTION
先前的游戏延迟加载在“game”和“game-local”文档初始化后立即进行，当本地游戏过滤启用时，由于路径有效性检查在此前的实现中是异步进行，本地过滤会将所有游戏视为非本地游戏，导致游戏库呈现为空。

此提交处理了对应逻辑，当本地游戏过滤启用时，路径检查会恰当的等待，，以便“gamesLoaded”信号与实际过滤器就绪状态匹配。