### PR TITLE
fix: sort VNDB name searches by searchrank

### DIFF
--- a/src/main/features/scraper/providers/vndb/common.ts
+++ b/src/main/features/scraper/providers/vndb/common.ts
@@ -16,6 +16,8 @@ import { net } from 'electron'
 import { ConfigDBManager } from '~/core/database'
 import i18next from 'i18next'
 
+const VNDB_SEARCH_SORT = 'searchrank'
+
 const VNDB_ROLE_MAPPING: Record<string, string> = {
   director: 'director',
   scenario: 'scenario',
@@ -101,6 +103,7 @@ export async function searchVNDBGames(gameName: string): Promise<SimpleGameInfo[
     const data = await fetchVNDB<VNBasicInfo>({
       filters: ['search', '=', gameName],
       fields,
+      sort: VNDB_SEARCH_SORT,
       results: 30
     })
 
@@ -193,7 +196,8 @@ export async function getVNMetadataByName(vnName: string): Promise<GameMetadata>
   try {
     const data = await fetchVNDB<VNDetailInfo>({
       filters: ['search', '=', vnName],
-      fields
+      fields,
+      sort: VNDB_SEARCH_SORT
     })
 
     if (!data.results.length) {
@@ -289,7 +293,8 @@ export async function getGameBackgroundsByName(name: string): Promise<string[]> 
   try {
     const data = await fetchVNDB<VNWithScreenshotsAndTitles>({
       filters: ['search', '=', name],
-      fields
+      fields,
+      sort: VNDB_SEARCH_SORT
     })
 
     if (data.results.length > 0) {
@@ -332,6 +337,7 @@ export async function getGameCoverByName(name: string): Promise<string> {
     const data = await fetchVNDB<VNWithCover>({
       filters: ['search', '=', name],
       fields,
+      sort: VNDB_SEARCH_SORT,
       results: 1
     })
 

--- a/src/main/features/scraper/providers/vndb/types.ts
+++ b/src/main/features/scraper/providers/vndb/types.ts
@@ -1,6 +1,7 @@
 export interface VNDBRequestParams {
   filters: Array<unknown>
   fields: string | string[]
+  sort?: string
   results?: number
 }
 


### PR DESCRIPTION
>Accepted values for "sort": id, title, released, rating, votecount, searchrank. [参考](https://api.vndb.org/kana#post-vn)

只有指定 sort 为 `searchrank` 时才与 vndb 站点搜索的结果一致，如果不指定 sort，则会出现搜索部分游戏时，完全搜不到目标游戏的情况

vnite 内搜索 island：
<img width="1285" height="1187" alt="image" src="https://github.com/user-attachments/assets/2be1c736-17ac-40ed-bf82-48fd7c3f35db" />
vndb 站点搜索 island：
<img width="465" height="381" alt="image" src="https://github.com/user-attachments/assets/c57202a5-6d6f-4a14-89bc-9ff9ffb6e397" />
