### PR TITLE
fix: narrow launcher game path guidance

### DIFF
--- a/src/renderer/src/components/Game/Config/Properties/Launcher/main.tsx
+++ b/src/renderer/src/components/Game/Config/Properties/Launcher/main.tsx
@@ -32,8 +32,20 @@ function LauncherComponent(
   const { t } = useTranslation('game')
   const [mode, setMode] = useGameLocalState(gameId, 'launcher.mode')
   const [gamePath] = useGameLocalState(gameId, 'path.gamePath')
+  const [fileConfig] = useGameLocalState(gameId, 'launcher.fileConfig')
+  const [urlConfig] = useGameLocalState(gameId, 'launcher.urlConfig')
+  const [scriptConfig] = useGameLocalState(gameId, 'launcher.scriptConfig')
   const [useMagpie, setUseMagpie] = useGameLocalState(gameId, 'launcher.useMagpie')
   const [magpiePath, setMagpiePath] = useConfigLocalState('game.linkage.magpie.path')
+  const shouldPromptUserToSetGamePath =
+    !gamePath &&
+    (mode === 'file'
+      ? !fileConfig.path && fileConfig.args.length === 0 && !fileConfig.monitorPath
+      : mode === 'url'
+        ? !urlConfig.url && !urlConfig.browserPath && !urlConfig.monitorPath
+        : !scriptConfig.workingDirectory &&
+          scriptConfig.command.length === 0 &&
+          !scriptConfig.monitorPath)
 
   async function selectMagpiePath(): Promise<void> {
     const magpiePath = await ipcManager.invoke('system:select-path-dialog', ['openFile'])
@@ -69,7 +81,7 @@ function LauncherComponent(
 
   return (
     <Card className={cn('group')}>
-      {gamePath ? (
+      {!shouldPromptUserToSetGamePath ? (
         <>
           <CardHeader>
             <CardTitle className={cn('relative')}>


### PR DESCRIPTION
在原先的版本中，只要 `gamePath` 为空，属性对话框就会提示用户设置 `gamePath`。这在游戏初次添加时具有引导作用，但是在用户手动编辑时具有误导性：因为它使对话框看起来好像删除 `gamePath` 的同时也清除了现有的启动器和跟踪配置，但是实际上对应配置仍然存在。尤其是在游戏追踪器升级后，软件已经能够直接监听从其他途径启动的游戏，使得此处隐藏的跟踪配置将会实际影响软件行为。

本提交收紧了此处的引导条件，仅当 gamePath 为空且当前模式的启动器配置也为空时才会出现提示。这使现有的启动和跟踪设置保持可见，避免暗示它们已重置。