### PR TITLE
refactor: isolate logo overlay to avoid page-wide rerenders while editing

### DIFF
--- a/src/renderer/src/components/Game/GameLogoOverlay.tsx
+++ b/src/renderer/src/components/Game/GameLogoOverlay.tsx
@@ -1,0 +1,281 @@
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { NSFWBlurLevel } from '@appTypes/models'
+import { Button } from '@ui/button'
+import { GameImage } from '@ui/game-image'
+import { useConfigState, useGameState } from '~/hooks'
+import { useGameDetailStore } from './store'
+
+type LogoPosition = {
+  x: number
+  y: number
+}
+
+const INITIAL_POSITION: LogoPosition = { x: 1.5, y: 35 }
+const INITIAL_POSITION_IN_COMPACT: LogoPosition = { x: 70, y: 5 }
+const INITIAL_SIZE = 100
+const LOGO_SCROLL_FACTOR = 1.3
+
+function isInitialPosition(position: LogoPosition): boolean {
+  return position.x === INITIAL_POSITION.x && position.y === INITIAL_POSITION.y
+}
+
+function getRenderedPosition(
+  position: LogoPosition,
+  headerLayout: 'default' | 'compact'
+): LogoPosition {
+  if (headerLayout === 'compact' && isInitialPosition(position)) {
+    return INITIAL_POSITION_IN_COMPACT
+  }
+
+  return position
+}
+
+export const GameLogoOverlay = React.memo(function GameLogoOverlay({
+  gameId,
+  scrollAreaRef
+}: {
+  gameId: string
+  scrollAreaRef: React.RefObject<HTMLDivElement | null>
+}): React.JSX.Element {
+  const { t } = useTranslation('game')
+  const logoRef = useRef<HTMLDivElement>(null)
+  const draggingRef = useRef(false)
+  const dragOffsetRef = useRef({ x: 0, y: 0 })
+  const scrollTopRef = useRef(0)
+  const rafIdRef = useRef<number | null>(null)
+  const [dragging, setDragging] = useState(false)
+
+  const [headerLayout] = useConfigState('appearances.gameDetail.headerLayout')
+  const [showLogo] = useConfigState('appearances.gameDetail.showLogo')
+  const [nsfwBlurLevel] = useConfigState('appearances.nsfwBlurLevel')
+  const [nsfw] = useGameState(gameId, 'apperance.nsfw')
+  const [logoPosition, setLogoPosition, saveLogoPosition] = useGameState(
+    gameId,
+    'apperance.logo.position',
+    true
+  )
+  const [logoSize, setLogoSize, saveLogoSize] = useGameState(gameId, 'apperance.logo.size', true)
+  const [logoVisible, setLogoVisible] = useGameState(gameId, 'apperance.logo.visible')
+  const isEditingLogo = useGameDetailStore((state) => state.isEditingLogo)
+  const setIsEditingLogo = useGameDetailStore((state) => state.setIsEditingLogo)
+
+  const hideLogo = nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage
+  const logoShown = showLogo && logoVisible && !hideLogo
+
+  const logoPositionRef = useRef<LogoPosition>(logoPosition)
+  const logoSizeRef = useRef(logoSize)
+  const headerLayoutRef = useRef(headerLayout)
+  const logoVisibleRef = useRef(logoVisible)
+  const setLogoPositionRef = useRef(setLogoPosition)
+
+  // Keep refs current so the long-lived pointer handlers can read fresh values.
+  if (!draggingRef.current) {
+    logoPositionRef.current = logoPosition
+    logoSizeRef.current = logoSize
+  }
+  headerLayoutRef.current = headerLayout
+  logoVisibleRef.current = logoVisible
+  setLogoPositionRef.current = setLogoPosition
+
+  const syncLogoStyle = (): void => {
+    if (!logoRef.current || !logoVisibleRef.current) return
+
+    const renderedPosition = getRenderedPosition(logoPositionRef.current, headerLayoutRef.current)
+    logoRef.current.style.left = `${renderedPosition.x}vw`
+    logoRef.current.style.top = `${renderedPosition.y}vh`
+    logoRef.current.style.transform = `translateY(-${scrollTopRef.current * LOGO_SCROLL_FACTOR}px) scale(${logoSizeRef.current / 100})`
+  }
+
+  const scheduleLogoStyleSync = (): void => {
+    if (rafIdRef.current !== null) return
+
+    rafIdRef.current = window.requestAnimationFrame(() => {
+      rafIdRef.current = null
+      syncLogoStyle()
+    })
+  }
+
+  // Re-apply the DOM-driven logo style after React updates persisted inputs.
+  useLayoutEffect(() => {
+    syncLogoStyle()
+  }, [gameId, headerLayout, logoPosition, logoSize, logoShown])
+
+  // Clear any carried-over parallax offset when navigating to a different game.
+  useEffect(() => {
+    scrollTopRef.current = 0
+    scheduleLogoStyleSync()
+  }, [gameId])
+
+  // Stop dragging immediately if the logo becomes hidden or masked mid-interaction.
+  useEffect(() => {
+    if (logoShown) return
+
+    draggingRef.current = false
+    setDragging(false)
+  }, [logoShown])
+
+  // Listen on the document so dragging continues even after the pointer leaves the logo.
+  useEffect(() => {
+    const handlePointerMove = (event: PointerEvent): void => {
+      if (!draggingRef.current) return
+
+      logoPositionRef.current = {
+        x: ((event.clientX - dragOffsetRef.current.x) * 100) / window.innerWidth,
+        y: ((event.clientY - dragOffsetRef.current.y) * 100) / window.innerHeight
+      }
+
+      syncLogoStyle()
+    }
+
+    const handlePointerUp = (): void => {
+      if (!draggingRef.current) return
+
+      draggingRef.current = false
+      setDragging(false)
+      void setLogoPositionRef.current(logoPositionRef.current)
+    }
+
+    document.addEventListener('pointermove', handlePointerMove)
+    document.addEventListener('pointerup', handlePointerUp)
+    document.addEventListener('pointercancel', handlePointerUp)
+
+    return (): void => {
+      document.removeEventListener('pointermove', handlePointerMove)
+      document.removeEventListener('pointerup', handlePointerUp)
+      document.removeEventListener('pointercancel', handlePointerUp)
+    }
+  }, [])
+
+  // Read the ScrollArea viewport position and mirror it into the logo parallax transform.
+  useEffect(() => {
+    if (!logoShown) return
+
+    const viewportElement = scrollAreaRef.current?.querySelector(
+      '[data-slot="scroll-area-viewport"]'
+    )
+    if (!viewportElement) return
+
+    const handleScroll = (): void => {
+      scrollTopRef.current = (viewportElement as HTMLElement).scrollTop
+      scheduleLogoStyleSync()
+    }
+
+    handleScroll()
+    viewportElement.addEventListener('scroll', handleScroll)
+
+    return (): void => {
+      viewportElement.removeEventListener('scroll', handleScroll)
+      if (rafIdRef.current !== null) {
+        window.cancelAnimationFrame(rafIdRef.current)
+        rafIdRef.current = null
+      }
+    }
+  }, [scrollAreaRef, gameId, logoShown])
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>): void => {
+    event.preventDefault()
+    if (!isEditingLogo) return
+    if (!logoRef.current) return
+    if (event.button !== 0) return
+
+    draggingRef.current = true
+    setDragging(true)
+
+    const renderedPosition = getRenderedPosition(logoPositionRef.current, headerLayoutRef.current)
+    dragOffsetRef.current = {
+      x: event.clientX - (renderedPosition.x * window.innerWidth) / 100,
+      y: event.clientY - (renderedPosition.y * window.innerHeight) / 100
+    }
+  }
+
+  const handleWheel = (event: React.WheelEvent<HTMLDivElement>): void => {
+    if (!isEditingLogo) return
+    event.preventDefault()
+
+    const delta = event.deltaY * -0.01
+    const nextSize = Math.min(Math.max(logoSizeRef.current + delta * 5, 30), 200)
+    logoSizeRef.current = nextSize
+    syncLogoStyle()
+    void setLogoSize(nextSize)
+  }
+
+  const handleResetPosition = (): void => {
+    logoPositionRef.current = INITIAL_POSITION
+    syncLogoStyle()
+    void setLogoPosition(INITIAL_POSITION)
+  }
+
+  const handleResetSize = (): void => {
+    logoSizeRef.current = INITIAL_SIZE
+    syncLogoStyle()
+    void setLogoSize(INITIAL_SIZE)
+  }
+
+  const handleConfirm = (): void => {
+    setIsEditingLogo(false)
+    void saveLogoPosition()
+    void saveLogoSize()
+  }
+
+  return (
+    <>
+      {showLogo && isEditingLogo && !hideLogo && (
+        <div className="absolute top-[10px] left-[10px] z-40 bg-transparent p-3 rounded-lg flex gap-3">
+          <Button
+            variant="default"
+            className="bg-primary hover:bg-primary/95"
+            onClick={handleResetPosition}
+          >
+            {t('detail.logoManagePanel.resetPosition')}
+          </Button>
+          <Button
+            variant="default"
+            className="bg-primary hover:bg-primary/95"
+            onClick={handleResetSize}
+          >
+            {t('detail.logoManagePanel.resetSize')}
+          </Button>
+          <Button
+            variant="default"
+            className="bg-primary hover:bg-primary/95"
+            onClick={() => void setLogoVisible(!logoVisible)}
+          >
+            {t(logoVisible ? 'detail.logoManagePanel.hideLogo' : 'detail.logoManagePanel.showLogo')}
+          </Button>
+          <Button
+            variant="default"
+            className="bg-primary hover:bg-primary/95"
+            onClick={handleConfirm}
+          >
+            {t('utils:common.confirm')}
+          </Button>
+        </div>
+      )}
+
+      {logoShown && (
+        <div
+          ref={logoRef}
+          onPointerDown={handlePointerDown}
+          onWheel={handleWheel}
+          style={{
+            cursor: isEditingLogo ? (dragging ? 'grabbing' : 'grab') : 'default',
+            transformOrigin: 'center center',
+            zIndex: isEditingLogo ? 30 : 10,
+            touchAction: 'none'
+          }}
+          className="absolute will-change-transform"
+        >
+          <GameImage
+            gameId={gameId}
+            key={`${gameId}-logo`}
+            type="logo"
+            className="w-auto max-h-[15vh] object-contain"
+            fallback={<div />}
+          />
+        </div>
+      )}
+    </>
+  )
+})

--- a/src/renderer/src/components/Game/main.tsx
+++ b/src/renderer/src/components/Game/main.tsx
@@ -1,23 +1,21 @@
-import { NSFWBlurLevel } from '@appTypes/models'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ImageViewerDialog } from '~/components/dialog/ImageViewerDialog'
-import { Button } from '~/components/ui/button'
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuTrigger
 } from '~/components/ui/context-menu'
-import { GameImage } from '~/components/ui/game-image'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
-import { useConfigState, useGameState } from '~/hooks'
+import { useConfigState } from '~/hooks'
 import { cn } from '~/utils'
 import { ScrollToTopButton } from '../Showcase/ScrollToTopButton'
 import { ScrollArea } from '../ui/scroll-area'
 import { PlayTimeEditorDialog } from './Config/ManageMenu/PlayTimeEditorDialog'
 import { ScoreEditorDialog } from './Config/ManageMenu/ScoreEditorDialog'
 import { GamePropertiesDialog } from './Config/Properties'
+import { GameLogoOverlay } from './GameLogoOverlay'
 import { Header } from './Header'
 import { HeaderCompact } from './HeaderCompact'
 import { Memory } from './Memory'
@@ -32,21 +30,10 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
   const { t } = useTranslation('game')
   const headerRef = useRef<HTMLDivElement>(null)
   const scrollAreaRef = useRef<HTMLDivElement>(null)
-  const [dragging, setDragging] = useState(false)
-  const offset = useRef({ x: 0, y: 0 })
-  const logoRef = useRef<HTMLDivElement>(null)
   const [headerLayout] = useConfigState('appearances.gameDetail.headerLayout')
-  const [showLogo] = useConfigState('appearances.gameDetail.showLogo')
-
-  // Add a ticking variable for requestAnimationFrame
-  const ticking = useRef(false)
-  // Store the current scroll position to avoid re-querying the DOM in the rAF callback
-  const currentScrollTop = useRef(0)
 
   const lastDetailTab = useGameDetailTabStore((s) => s.lastDetailTab)
   const setLastDetailTab = useGameDetailTabStore((s) => s.setLastDetailTab)
-  const isEditingLogo = useGameDetailStore((state) => state.isEditingLogo)
-  const setIsEditingLogo = useGameDetailStore((state) => state.setIsEditingLogo)
   const isInformationDialogOpen = useGameDetailStore((s) => s.isInformationDialogOpen)
   const setIsInformationDialogOpen = useGameDetailStore((s) => s.setIsInformationDialogOpen)
   const propertiesDialogState = useGameDetailStore((s) => s.propertiesDialog)
@@ -62,118 +49,29 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
   const isScoreEditorDialogOpen = useGameDetailStore((state) => state.isScoreEditorDialogOpen)
   const setIsScoreEditorDialogOpen = useGameDetailStore((state) => state.setIsScoreEditorDialogOpen)
 
-  // Game Logo position and size management
-  const initialPosition = { x: 1.5, y: 35 }
-  const initialPositionInCompact = { x: 70, y: 5 } // Adjusted for compact header
-  const initialSize = 100
-  const [logoPosition, setLogoPosition, saveLogoPosition] = useGameState(
-    gameId,
-    'apperance.logo.position',
-    true
-  )
-  const [logoSize, setLogoSize, saveLogoSize] = useGameState(gameId, 'apperance.logo.size', true)
-  const [logoVisible, setLogoVisible] = useGameState(gameId, 'apperance.logo.visible')
-  const [localLogoPosition, setLocalLogoPosition] = useState(initialPosition)
-
-  const [nsfwBlurLevel] = useConfigState('appearances.nsfwBlurLevel')
-  const [nsfw] = useGameState(gameId, 'apperance.nsfw')
-  const hideLogo = nsfw && nsfwBlurLevel >= NSFWBlurLevel.BlurImage
-
-  useEffect(() => {
-    setLocalLogoPosition(logoPosition)
-  }, [logoPosition])
-
-  // Logo-related handler functions
-  const handleMouseMove = (e: MouseEvent): void => {
-    if (dragging && logoRef.current) {
-      setLocalLogoPosition({
-        x: ((e.clientX - offset.current.x) * 100) / window.innerWidth,
-        y: ((e.clientY - offset.current.y) * 100) / window.innerHeight
-      })
-    }
-  }
-
-  const handleMouseUp = async (): Promise<void> => {
-    if (dragging) {
-      setLogoPosition(localLogoPosition)
-    }
-    setDragging(false)
-  }
-
-  const handleReset = async (): Promise<void> => {
-    setLocalLogoPosition(initialPosition)
-    setLogoPosition(initialPosition)
-  }
-
-  const handleWheel = (e: React.WheelEvent<HTMLDivElement>): void => {
-    e.preventDefault()
-    if (!logoRef.current) return
-
-    const delta = e.deltaY * -0.01
-    const newSize = Math.min(Math.max(logoSize + delta * 5, 30), 200) // Limit size between 30% and 200%
-    setLogoSize(newSize)
-  }
-
-  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>): void => {
-    e.preventDefault()
-    if (!isEditingLogo) return
-    if (!logoRef.current) return
-    if (e.button === 0) {
-      setDragging(true)
-      offset.current = {
-        x: e.clientX - (localLogoPosition.x * window.innerWidth) / 100,
-        y: e.clientY - (localLogoPosition.y * window.innerHeight) / 100
-      }
-    }
-  }
-
-  // Use requestAnimationFrame for smoother updates
-  const updateLogoPosition = (): void => {
-    if (logoRef.current && logoVisible) {
-      logoRef.current.style.transform = `translateY(-${currentScrollTop.current * 1.3}px) scale(${logoSize / 100})`
-    }
-    ticking.current = false
-  }
-
   // Reset scroll position when gameId changes
   useEffect(() => {
-    // Reset scroll position
-    currentScrollTop.current = 0
-
-    // Find and reset the scroll container's position
-    if (scrollAreaRef.current) {
-      const viewportElement = scrollAreaRef.current.querySelector('[class*="size-full"]')
-      if (viewportElement) {
-        ;(viewportElement as HTMLElement).scrollTop = 0
-      }
-    }
+    const viewportElement = scrollAreaRef.current?.querySelector(
+      '[data-slot="scroll-area-viewport"]'
+    )
+    if (!viewportElement) return
+    viewportElement.scrollTop = 0
   }, [gameId])
 
-  // Scroll handling with imperative updates and requestAnimationFrame
+  // Forward game detail scroll position to Light page effects.
   useEffect(() => {
-    if (!scrollAreaRef.current) return
-
-    const viewportElement = scrollAreaRef.current.querySelector('[class*="size-full"]')
-
+    const viewportElement = scrollAreaRef.current?.querySelector(
+      '[data-slot="scroll-area-viewport"]'
+    )
     if (!viewportElement) {
       console.error('ScrollArea viewport element not found')
       return
     }
 
     const handleScroll = (): void => {
-      // Store the current scroll position
-      currentScrollTop.current = (viewportElement as HTMLElement).scrollTop
-
-      // Use requestAnimationFrame for smoother updates
-      if (!ticking.current) {
-        window.requestAnimationFrame(updateLogoPosition)
-        ticking.current = true
-      }
-
-      // Dispatch a custom event to notify Light components of the scroll position
       window.dispatchEvent(
         new CustomEvent('game-scroll', {
-          detail: { scrollY: currentScrollTop.current }
+          detail: { scrollY: viewportElement.scrollTop }
         })
       )
     }
@@ -185,115 +83,11 @@ export function Game({ gameId }: { gameId: string }): React.JSX.Element {
     return (): void => {
       viewportElement.removeEventListener('scroll', handleScroll)
     }
-  }, [logoSize, logoVisible])
-
-  // Mouse event listeners
-  useEffect(() => {
-    document.addEventListener('mousemove', handleMouseMove)
-    document.addEventListener('mouseup', handleMouseUp)
-
-    return (): void => {
-      document.removeEventListener('mousemove', handleMouseMove)
-      document.removeEventListener('mouseup', handleMouseUp)
-    }
-  }, [dragging, localLogoPosition])
-
-  const isInitialPosition = (pos: { x: number; y: number }): boolean =>
-    pos.x === initialPosition.x && pos.y === initialPosition.y
+  }, [])
 
   return (
     <div className={cn('w-full h-full relative overflow-hidden shrink-0')}>
-      {/* Logo Editing Control Panel */}
-      {/* Only visible when editing logo */}
-      {showLogo && isEditingLogo && !hideLogo && (
-        <div
-          className={cn(
-            'absolute top-[10px] left-[10px] z-40 bg-transparent p-3 rounded-lg flex gap-3'
-          )}
-        >
-          <Button
-            variant={'default'}
-            className={cn('bg-primary hover:bg-primary/95')}
-            onClick={handleReset}
-          >
-            {t('detail.logoManagePanel.resetPosition')}
-          </Button>
-          <Button
-            variant={'default'}
-            className={cn('bg-primary hover:bg-primary/95')}
-            onClick={() => setLogoSize(initialSize)}
-          >
-            {t('detail.logoManagePanel.resetSize')}
-          </Button>
-          {logoVisible ? (
-            <Button
-              variant={'default'}
-              className={cn('bg-primary hover:bg-primary/95')}
-              onClick={() => {
-                setLogoVisible(false)
-              }}
-            >
-              {t('detail.logoManagePanel.hideLogo')}
-            </Button>
-          ) : (
-            <Button
-              variant={'default'}
-              className={cn('bg-primary hover:bg-primary/95')}
-              onClick={() => {
-                setLogoVisible(true)
-              }}
-            >
-              {t('detail.logoManagePanel.showLogo')}
-            </Button>
-          )}
-          <Button
-            variant={'default'}
-            className={cn('bg-primary hover:bg-primary/95')}
-            onClick={() => {
-              setIsEditingLogo(false)
-              saveLogoPosition()
-              saveLogoSize()
-            }}
-          >
-            {t('utils:common.confirm')}
-          </Button>
-        </div>
-      )}
-
-      {/* Logo Layer */}
-      {showLogo && logoVisible && !hideLogo && (
-        <ContextMenu>
-          <ContextMenuTrigger asChild>
-            <div
-              ref={logoRef}
-              onMouseDown={handleMouseDown}
-              onWheel={handleWheel}
-              style={{
-                transform: `scale(${logoSize / 100})`,
-                left: `${headerLayout === 'compact' && isInitialPosition(localLogoPosition) ? initialPositionInCompact.x : localLogoPosition.x}vw`,
-                top: `${headerLayout === 'compact' && isInitialPosition(localLogoPosition) ? initialPositionInCompact.y : localLogoPosition.y}vh`,
-                cursor: isEditingLogo ? (dragging ? 'grabbing' : 'grab') : 'default',
-                transformOrigin: 'center center',
-                zIndex: isEditingLogo ? 30 : 10
-              }}
-              className={cn('absolute', 'will-change-transform')}
-            >
-              <GameImage
-                gameId={gameId}
-                key={`${gameId}-logo`}
-                type="logo"
-                className={cn('w-auto max-h-[15vh] object-contain')}
-                fallback={<div className={cn('')} />}
-              />
-            </div>
-          </ContextMenuTrigger>
-          <ContextMenuContent className={cn('w-40')}>
-            <ContextMenuItem onSelect={() => openPropertiesDialog('media')}>
-              {t('detail.contextMenu.editMediaProperties')}
-            </ContextMenuItem>
-          </ContextMenuContent>
-        </ContextMenu>
-      )}
+      <GameLogoOverlay gameId={gameId} scrollAreaRef={scrollAreaRef} />
 
       {/* Scrollable Content Area */}
       <ScrollArea


### PR DESCRIPTION
原先的游戏徽标组件内联在游戏详情页顶端，这会导致徽标编辑过程中产生的状态更新触发整个详情页的重渲染，并在某些设备上触发`Maximum update depth exceeded`（#626）。

本提交将游戏徽标相关逻辑提取为单独组件，避免编辑过程中触发整个详情页的重渲染，以期修复上述问题。

Fix #626