### PR TITLE
fix: recover google image searches behind challenge pages

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,6 +36,7 @@ import {
   checkIfDirectoryNeedsAdminRights,
   cleanupPowerShell,
   parseGameIdFromUrl,
+  primeGoogleImageSearchSession,
   restartAppAsAdmin
 } from './utils'
 
@@ -325,6 +326,8 @@ app.whenReady().then(async () => {
     // dock icon is clicked and there are no other windows open.
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
+
+  void primeGoogleImageSearchSession()
 })
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/src/main/utils/gis.ts
+++ b/src/main/utils/gis.ts
@@ -1,6 +1,24 @@
-import { net } from 'electron'
+import { BrowserWindow, net } from 'electron'
+import log from 'electron-log/main'
+
+import { delay } from './common'
 
 const REGEX = /\["(\bhttps?:\/\/[^"]+)",(\d+),(\d+)\],null/g
+const GOOGLE_IMAGE_SEARCH_BASE_URL = 'https://www.google.com/search'
+const GOOGLE_IMAGE_SEARCH_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36'
+
+// Challenge warm-up
+const GOOGLE_IMAGE_SEARCH_CHALLENGE_TIMEOUT_MS = 30_000
+const GOOGLE_IMAGE_SEARCH_CHALLENGE_POLL_INTERVAL_MS = 1_000
+const GOOGLE_IMAGE_SEARCH_POST_VERIFY_DELAY_MS = 750
+const GOOGLE_IMAGE_SEARCH_CHALLENGE_URL = `${GOOGLE_IMAGE_SEARCH_BASE_URL}?${new URLSearchParams({
+  udm: '2',
+  tbm: 'isch',
+  q: 'google'
+}).toString()}`
+
+let googleChallengePromise: Promise<void> | null = null
 
 const unicodeToString = (content: string): string =>
   content.replace(/\\u[\dA-F]{4}/gi, (match) =>
@@ -16,41 +34,91 @@ export interface Result {
 
 export interface Options {
   query?: Record<string, string>
-  userAgent?: string
 }
 
 export async function gis(searchTerm: string, options: Options = {}): Promise<Result[]> {
-  if (!searchTerm || typeof searchTerm !== 'string')
+  if (!searchTerm || typeof searchTerm !== 'string') {
     throw new TypeError('searchTerm must be a string.')
+  }
 
-  if (typeof options !== 'object') throw new TypeError('options parameter must be an object.')
+  if (!options || typeof options !== 'object') {
+    throw new TypeError('options parameter must be an object.')
+  }
 
-  const {
-    query = {},
-    userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36'
-  } = options
+  const { query = {} } = options
+  const searchUrl = `${GOOGLE_IMAGE_SEARCH_BASE_URL}?${new URLSearchParams({
+    ...query,
+    udm: '2',
+    tbm: 'isch',
+    q: searchTerm
+  }).toString()}`
 
-  const response = await net.fetch(
-    `http://www.google.com/search?${new URLSearchParams({
-      ...query,
-      udm: '2',
-      tbm: 'isch',
-      q: searchTerm
-    }).toString()}`,
-    {
-      headers: {
-        'User-Agent': userAgent
-      }
+  let { response, body } = await fetchGoogleImageSearchPage(searchUrl)
+  if (!response.ok) {
+    throw new Error(`Google image search request failed with status ${response.status}`)
+  }
+
+  let results = extractGoogleImageSearchResults(body)
+  if (results.length === 0) {
+    log.warn(
+      `[GIS] Google image search returned no image results for search term "${searchTerm}". A challenge page may have been returned, so session verification will be attempted.`
+    )
+    await ensureGoogleChallengeResolved()
+    await delay(GOOGLE_IMAGE_SEARCH_POST_VERIFY_DELAY_MS)
+    ;({ response, body } = await fetchGoogleImageSearchPage(searchUrl))
+    results = extractGoogleImageSearchResults(body)
+  }
+
+  return results
+}
+
+export async function primeGoogleImageSearchSession(): Promise<void> {
+  try {
+    const { response, body } = await fetchGoogleImageSearchPage(GOOGLE_IMAGE_SEARCH_CHALLENGE_URL)
+
+    if (!response.ok) {
+      log.warn(
+        `[GIS] Google image search warm-up request returned status ${response.status}. Skipping verification.`
+      )
+      return
     }
-  )
 
-  const body = await response.text()
-  const content = body // will fix
+    const results = extractGoogleImageSearchResults(body)
+    if (results.length > 0) {
+      log.info(`[GIS] Google image search warm-up completed without challenge.`)
+      return
+    }
 
+    log.info('[GIS] Google image search warm-up returned no image results. Opening helper window.')
+    await ensureGoogleChallengeResolved()
+    log.info('[GIS] Google image search warm-up completed after session verification.')
+  } catch (error) {
+    log.warn(`[GIS] Google image search warm-up failed: ${String(error)}`)
+  }
+}
+
+async function fetchGoogleImageSearchPage(
+  url: string
+): Promise<{ response: Response; body: string }> {
+  const response = await net.fetch(url, {
+    headers: {
+      'User-Agent': GOOGLE_IMAGE_SEARCH_USER_AGENT
+    }
+  })
+
+  return {
+    response,
+    body: await response.text()
+  }
+}
+
+function extractGoogleImageSearchResults(content: string): Result[] {
+  // Clone the global regex so each parse starts with a fresh lastIndex.
+  const pattern = new RegExp(REGEX)
   const results: Result[] = []
   let match: RegExpExecArray | null
 
-  while ((match = REGEX.exec(content)) !== null) {
+  while ((match = pattern.exec(content)) !== null) {
     results.push({
       url: unicodeToString(match[1]),
       height: +match[2],
@@ -59,4 +127,77 @@ export async function gis(searchTerm: string, options: Options = {}): Promise<Re
   }
 
   return results
+}
+
+async function ensureGoogleChallengeResolved(): Promise<void> {
+  if (!googleChallengePromise) {
+    googleChallengePromise = resolveGoogleChallenge().finally(() => {
+      googleChallengePromise = null
+    })
+  }
+
+  return googleChallengePromise
+}
+
+async function resolveGoogleChallenge(): Promise<void> {
+  const helperWindow = new BrowserWindow({
+    width: 640,
+    height: 860,
+    show: false,
+    webPreferences: {
+      sandbox: false,
+      backgroundThrottling: false
+    }
+  })
+
+  try {
+    await loadGoogleVerificationUrl(helperWindow)
+
+    const timeoutAt = Date.now() + GOOGLE_IMAGE_SEARCH_CHALLENGE_TIMEOUT_MS
+
+    while (Date.now() < timeoutAt) {
+      if (helperWindow.isDestroyed()) {
+        throw new Error('Google verification window was closed before the challenge completed')
+      }
+
+      let hasResults = false
+      try {
+        const content = await helperWindow.webContents.executeJavaScript(
+          `(() => document.documentElement?.outerHTML || '')()`,
+          true
+        )
+        hasResults = new RegExp(REGEX).test(content)
+      } catch {
+        hasResults = false
+      }
+
+      if (hasResults) {
+        log.info(`[GIS] Google session verification completed.`)
+        return
+      }
+
+      await delay(GOOGLE_IMAGE_SEARCH_CHALLENGE_POLL_INTERVAL_MS)
+    }
+
+    throw new Error(`Timed out waiting for Google challenge page to resolve.`)
+  } finally {
+    if (!helperWindow.isDestroyed()) {
+      helperWindow.close()
+    }
+  }
+}
+
+async function loadGoogleVerificationUrl(helperWindow: BrowserWindow): Promise<void> {
+  try {
+    await helperWindow.loadURL(GOOGLE_IMAGE_SEARCH_CHALLENGE_URL, {
+      userAgent: GOOGLE_IMAGE_SEARCH_USER_AGENT
+    })
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('ERR_ABORTED')) {
+      // Google may interrupt the initial navigation with a redirect while the verification page is loading.
+      return
+    }
+
+    throw error
+  }
 }


### PR DESCRIPTION
修复了Google图片搜索无返回的问题。

### 实现细节

当 Google 图片搜索返回挑战页时，程序会启动一个隐藏的 `BrowserWindow` 来完成 Google 的 JS 挑战流程。挑战通过后，相关 Cookie 会保存到当前 Electron 的会话数据中（`%APPDATA%/vnite/Network`），因此后续的图片搜索请求通常都可以正常返回结果；在本地会话未被清理的情况下，这个状态在应用重启后通常也会继续保留。

当前有两个触发时机：
- 程序启动时，会先发起一次预热请求；如果没有返回可解析的图片结果，则执行挑战流程
- 每次 Google 图片搜索请求时，如果当前请求没有返回可解析的图片结果，则执行挑战流程

Fix #623, Fix #581