### PR TITLE
fix: sort merged play time data by date in getGamePlayTimeByDateRange

### DIFF
--- a/src/renderer/src/stores/game/gameUtils.ts
+++ b/src/renderer/src/stores/game/gameUtils.ts
@@ -742,7 +742,11 @@ export function getGamePlayTimeByDateRange(
       )
     }
 
-    return dailyPlayTime
+    const sorted: Record<string, number> = {}
+    for (const key of Object.keys(dailyPlayTime).sort()) {
+      sorted[key] = dailyPlayTime[key]
+    }
+    return sorted
   } catch (error) {
     console.error(`Fatal error in getGamePlayTimeByDateRange for ${gameId}:`, error)
     return {}


### PR DESCRIPTION
修复了单个游戏游玩记录图表日期项顺序错乱的问题

Fix #632