### PR TITLE
fix: improve description HTML rendering and allow local image paths

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: http: data: attachment: file: blob:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: http: data: attachment: file: blob:; media-src 'self' https: http: data: attachment: file: blob:"
     />
   </head>
 

--- a/src/renderer/src/components/Game/Overview/description/DescriptionCard.tsx
+++ b/src/renderer/src/components/Game/Overview/description/DescriptionCard.tsx
@@ -69,11 +69,11 @@ export function DescriptionCard({
           value={description}
           emptyLabel={t('detail.overview.description.empty')}
           className={cn(
-            'text-sm',
+            'prose prose-sm dark:prose-invert max-w-none',
+            'prose-headings:my-1', // Reduce heading margins for better spacing
             'prose-a:text-primary', // Link Color
             'prose-a:no-underline hover:prose-a:underline', // underline effect
             'space-before-0',
-            'whitespace-pre-line',
             'break-words',
             'leading-7'
           )}

--- a/src/renderer/src/components/Game/Overview/description/DescriptionHtmlContent.tsx
+++ b/src/renderer/src/components/Game/Overview/description/DescriptionHtmlContent.tsx
@@ -1,9 +1,43 @@
 import DOMPurify from 'dompurify'
-import parse from 'html-react-parser'
-import { useMemo } from 'react'
+import parse, { Element, type HTMLReactParserOptions, Text } from 'html-react-parser'
+import { Fragment, useMemo } from 'react'
 import { cn, HTMLParserOptions } from '~/utils'
 
-const DESCRIPTION_HTML_ALLOWED_URI_REGEXP = /^(?:(?:https?|attachment):)/i
+const DESCRIPTION_HTML_ALLOWED_URI_REGEXP = /^(?:(?:https?|attachment|file):|[a-z]:[/\\])/i
+
+function renderTextWithLineBreaks(text: string): React.JSX.Element {
+  const parts = text.split(/\r\n|\r|\n/)
+
+  return (
+    <>
+      {parts.map((part, index) => (
+        <Fragment key={index}>
+          {index > 0 && <br />}
+          {part}
+        </Fragment>
+      ))}
+    </>
+  )
+}
+
+const DESCRIPTION_HTML_PARSER_OPTIONS: HTMLReactParserOptions = {
+  ...HTMLParserOptions,
+  replace: (domNode, index) => {
+    HTMLParserOptions.replace?.(domNode, index)
+
+    // Steam wraps content in heading tags with class "bb_tag" — render as plain text
+    if (domNode instanceof Element && domNode.attribs.class?.includes('bb_tag')) {
+      domNode.name = 'p'
+      delete domNode.attribs.class
+    }
+
+    if (domNode instanceof Text && /[\r\n]/.test(domNode.data) && domNode.data.trim()) {
+      return renderTextWithLineBreaks(domNode.data)
+    }
+
+    return
+  }
+}
 
 export function DescriptionHtmlContent({
   value,
@@ -27,5 +61,7 @@ export function DescriptionHtmlContent({
     return <div className={cn(className)}>{emptyLabel}</div>
   }
 
-  return <div className={cn(className)}>{parse(sanitizedHtml, HTMLParserOptions)}</div>
+  return (
+    <div className={cn(className)}>{parse(sanitizedHtml, DESCRIPTION_HTML_PARSER_OPTIONS)}</div>
+  )
 }

--- a/src/renderer/src/components/Game/Overview/description/SearchDescriptionDialog.tsx
+++ b/src/renderer/src/components/Game/Overview/description/SearchDescriptionDialog.tsx
@@ -111,11 +111,11 @@ export function SearchDescriptionDialog({
                       <DescriptionHtmlContent
                         value={item.description}
                         className={cn(
-                          'text-sm',
+                          'prose prose-sm dark:prose-invert max-w-none',
+                          'prose-headings:my-1', // Reduce heading margins for better spacing
                           'prose-a:text-primary', // Link Color
                           'prose-a:no-underline hover:prose-a:underline', // underline effect
                           'space-before-0',
-                          'whitespace-pre-line',
                           'break-words',
                           'leading-7'
                         )}


### PR DESCRIPTION
- 修复简介栏无法正常渲染标题样式的问题
- 修复简介栏无法渲染本地图片的问题
- 修复简介栏无法显示视频的问题
- 优化了HTML混合纯文本的情形下对换行的渲染

Fix #635
Fix #643
