### PR TITLE
Opti/record

### DIFF
--- a/src/renderer/locales/en/record.json
+++ b/src/renderer/locales/en/record.json
@@ -92,7 +92,7 @@
       "playTime": "Play Time: {{time, gameTime}}"
     },
     "chart": {
-      "weeklyPlayTime": "Weekly Play Time",
+      "dailyPlayTime": "Daily Play Time",
       "calendarTitle": "Monthly Gaming Calendar",
       "weekFormat": "Week {{week}}",
       "weekDateRange": "{{week}} ({{startDay}}-{{endDay}})",

--- a/src/renderer/locales/fr/record.json
+++ b/src/renderer/locales/fr/record.json
@@ -85,7 +85,7 @@
       "playTime": ""
     },
     "chart": {
-      "weeklyPlayTime": "",
+      "dailyPlayTime": "",
       "calendarTitle": "",
       "weekFormat": "",
       "weekDateRange": ""

--- a/src/renderer/locales/it/record.json
+++ b/src/renderer/locales/it/record.json
@@ -85,7 +85,7 @@
       "playTime": ""
     },
     "chart": {
-      "weeklyPlayTime": "",
+      "dailyPlayTime": "",
       "calendarTitle": "",
       "weekFormat": "",
       "weekDateRange": ""

--- a/src/renderer/locales/ja/record.json
+++ b/src/renderer/locales/ja/record.json
@@ -92,7 +92,7 @@
       "playTime": "プレイ時間：{{time, gameTime}}"
     },
     "chart": {
-      "weeklyPlayTime": "週間プレイ時間",
+      "dailyPlayTime": "日別プレイ時間",
       "calendarTitle": "月間ゲームカレンダー",
       "weekFormat": "第{{week}}週",
       "weekDateRange": "{{week}}（{{startDay}}日-{{endDay}}日）",

--- a/src/renderer/locales/ko/record.json
+++ b/src/renderer/locales/ko/record.json
@@ -85,7 +85,7 @@
       "playTime": "플레이 시간: {{time, gameTime}}"
     },
     "chart": {
-      "weeklyPlayTime": "주간 플레이 시간",
+      "dailyPlayTime": "일별 플레이 시간",
       "calendarTitle": "월간 게임 달력",
       "weekFormat": "{{week}}번째 주",
       "weekDateRange": "{{week}} ({{startDay}}일~{{endDay}}일)"

--- a/src/renderer/locales/ru/record.json
+++ b/src/renderer/locales/ru/record.json
@@ -85,7 +85,7 @@
       "playTime": "Время игры: {{time, gameTime}}"
     },
     "chart": {
-      "weeklyPlayTime": "Еженедельное время игры",
+      "dailyPlayTime": "Ежедневное время игры",
       "calendarTitle": "Календарь за месяц",
       "weekFormat": "Неделя {{week}}",
       "weekDateRange": "Нед. {{week}} ({{startDay}}–{{endDay}})"

--- a/src/renderer/locales/uk/record.json
+++ b/src/renderer/locales/uk/record.json
@@ -92,7 +92,7 @@
       "playTime": ""
     },
     "chart": {
-      "weeklyPlayTime": "",
+      "dailyPlayTime": "",
       "calendarTitle": "",
       "weekFormat": "",
       "weekDateRange": "",

--- a/src/renderer/locales/zh-CN/record.json
+++ b/src/renderer/locales/zh-CN/record.json
@@ -92,7 +92,7 @@
       "playTime": "游戏时长：{{time, gameTime}}"
     },
     "chart": {
-      "weeklyPlayTime": "每周游戏时长",
+      "dailyPlayTime": "每日游戏时长",
       "calendarTitle": "月度游戏日历",
       "weekFormat": "第{{week}}周",
       "weekDateRange": "{{week}}（{{startDay}}日-{{endDay}}日）",

--- a/src/renderer/locales/zh-TW/record.json
+++ b/src/renderer/locales/zh-TW/record.json
@@ -92,7 +92,7 @@
       "playTime": "遊戲時長：{{time, gameTime}}"
     },
     "chart": {
-      "weeklyPlayTime": "每週遊戲時長",
+      "dailyPlayTime": "每日遊戲時長",
       "calendarTitle": "月度遊戲日曆",
       "weekFormat": "第{{week}}周",
       "weekDateRange": "{{week}}（{{startDay}}日-{{endDay}}日）",

--- a/src/renderer/src/components/Game/Record/ChartCard.tsx
+++ b/src/renderer/src/components/Game/Record/ChartCard.tsx
@@ -1,9 +1,11 @@
-import { DateTimeInput } from '@ui/date-input'
-import { isEqual } from 'lodash'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { StepperInput } from '~/components/ui/input'
-import { SeparatorDashed } from '~/components/ui/separator-dashed'
+
+import { DateTimeInput } from '@ui/date-input'
+import { StepperInput } from '@ui/input'
+import { SeparatorDashed } from '@ui/separator-dashed'
+import { useGameState } from '~/hooks'
+import type { GameRecordCalculationSource } from '~/stores/game'
 import { getGamePlayTimeByDateRange, getGameStartAndEndDate } from '~/stores/game'
 import { cn } from '~/utils'
 import { DailyPlayTime, TimeGranularity, TimerChart } from './TimerChart'
@@ -40,43 +42,55 @@ export function ChartCard({
   className?: string
 }): React.JSX.Element {
   const { t } = useTranslation('game')
-  const timers = getGameStartAndEndDate(gameId)
+  const [recordTimers] = useGameState(gameId, 'record.timers')
+  const [dailyPlayTimes] = useGameState(gameId, 'record.dailyPlayTimes')
   const [startDate, setStartDate] = useState('')
   const [endDate, setEndDate] = useState('')
   const [minValue, setMinValue] = useState(0)
-  const [playTimeByDateRange, setPlayTimeByDateRange] = useState<Record<string, number>>({})
-  const [granularity, setGranularity] = useState<TimeGranularity>('day')
+
+  const calculationSource = useMemo<GameRecordCalculationSource>(
+    () => ({
+      timers: recordTimers,
+      dailyPlayTimes
+    }),
+    [recordTimers, dailyPlayTimes]
+  )
+
+  const availableRange = useMemo(
+    () => getGameStartAndEndDate(gameId, calculationSource),
+    [gameId, calculationSource]
+  )
 
   useEffect(() => {
-    setStartDate(timers.start)
-    setEndDate(timers.end)
-  }, [timers.start, timers.end])
+    setStartDate(availableRange.start)
+    setEndDate(availableRange.end)
+  }, [availableRange.start, availableRange.end])
 
   const isDateInRange = (date: string): boolean => {
-    if (!date || !timers.start || !timers.end) return false
-    return date >= timers.start && date <= timers.end
+    if (!date || !availableRange.start || !availableRange.end) return false
+    return date >= availableRange.start && date <= availableRange.end
   }
 
-  useEffect(() => {
-    // Get data only if both dates are valid and within the allowed range
-    if (
-      startDate &&
-      endDate &&
+  const playTimeByDateRange = useMemo(
+    () =>
+      Boolean(startDate && endDate) &&
       isDateInRange(startDate) &&
       isDateInRange(endDate) &&
       startDate <= endDate
-    ) {
-      const data = getGamePlayTimeByDateRange(gameId, startDate, endDate)
-      setPlayTimeByDateRange(data)
-      setGranularity(recommendGranularity(data))
-    }
-  }, [startDate, endDate, timers.start, timers.end, gameId])
+        ? getGamePlayTimeByDateRange(gameId, startDate, endDate, calculationSource)
+        : {},
+    [startDate, endDate, gameId, calculationSource]
+  )
+  const granularity = useMemo(
+    () => recommendGranularity(playTimeByDateRange),
+    [playTimeByDateRange]
+  )
 
   return (
     <div className={cn(className, 'flex flex-col')}>
       <div className={cn('font-bold')}>{t('detail.chart.title')}</div>
       <SeparatorDashed />
-      {!isEqual(timers, { start: '', end: '' }) ? (
+      {availableRange.start && availableRange.end ? (
         <>
           <div className={cn('flex flex-row gap-2 items-center')}>
             <DateTimeInput
@@ -114,7 +128,10 @@ export function ChartCard({
             <div>{t('detail.chart.dateError')}</div>
           ) : !isDateInRange(startDate) || !isDateInRange(endDate) ? (
             <div>
-              {t('detail.chart.rangeLimit', { startDate: timers.start, endDate: timers.end })}
+              {t('detail.chart.rangeLimit', {
+                startDate: availableRange.start,
+                endDate: availableRange.end
+              })}
             </div>
           ) : (
             <div className={cn('max-h-full rounded-lg py-3', '3xl:max-h-full')}>

--- a/src/renderer/src/components/Game/Record/ChartCard.tsx
+++ b/src/renderer/src/components/Game/Record/ChartCard.tsx
@@ -8,7 +8,7 @@ import { useGameState } from '~/hooks'
 import type { GameRecordCalculationSource } from '~/stores/game'
 import { getGamePlayTimeByDateRange, getGameStartAndEndDate } from '~/stores/game'
 import { cn } from '~/utils'
-import { DailyPlayTime, TimeGranularity, TimerChart } from './TimerChart'
+import { DailyPlayTime, HelpText, TimeGranularity, TimerChart } from './TimerChart'
 
 function recommendGranularity(chartData: DailyPlayTime): TimeGranularity {
   const monthSet = new Set<string>()
@@ -123,21 +123,21 @@ export function ChartCard({
             )}
           </div>
           {!startDate || !endDate ? (
-            t('detail.chart.selectRange')
+            <HelpText info={t('detail.chart.selectRange')} />
           ) : startDate > endDate ? (
-            <div>{t('detail.chart.dateError')}</div>
+            <HelpText info={t('detail.chart.dateError')} />
           ) : !isDateInRange(startDate) || !isDateInRange(endDate) ? (
-            <div>
-              {t('detail.chart.rangeLimit', {
+            <HelpText
+              info={t('detail.chart.rangeLimit', {
                 startDate: availableRange.start,
                 endDate: availableRange.end
               })}
-            </div>
+            />
           ) : (
             <div className={cn('max-h-full rounded-lg py-3', '3xl:max-h-full')}>
               <TimerChart
                 data={playTimeByDateRange}
-                minMinutes={granularity === 'day' ? 0 : minValue}
+                minMinutes={granularity === 'day' ? minValue : 0}
                 className={cn('w-full max-h-[30vh] -ml-3')}
                 granularity={granularity}
               />
@@ -145,7 +145,7 @@ export function ChartCard({
           )}
         </>
       ) : (
-        <div>{t('detail.chart.noData')}</div>
+        <HelpText info={t('detail.chart.noData')} />
       )}
     </div>
   )

--- a/src/renderer/src/components/Game/Record/RecordCard.tsx
+++ b/src/renderer/src/components/Game/Record/RecordCard.tsx
@@ -1,6 +1,9 @@
+import { useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { SeparatorDashed } from '~/components/ui/separator-dashed'
+
+import { SeparatorDashed } from '@ui/separator-dashed'
 import { useGameState } from '~/hooks'
+import type { GameRecordCalculationSource } from '~/stores/game'
 import { getGameMaxPlayTimeDay, getGamePlayDays } from '~/stores/game'
 import { cn } from '~/utils'
 
@@ -13,11 +16,26 @@ export function RecordCard({
 }): React.JSX.Element {
   const { t } = useTranslation('game')
   const [addDate] = useGameState(gameId, 'record.addDate')
-  const playDays = getGamePlayDays(gameId)
   const [playingTime] = useGameState(gameId, 'record.playTime')
   const [lastRunDate] = useGameState(gameId, 'record.lastRunDate')
+  const [recordTimers] = useGameState(gameId, 'record.timers')
+  const [dailyPlayTimes] = useGameState(gameId, 'record.dailyPlayTimes')
+
+  const calculationSource = useMemo<GameRecordCalculationSource>(
+    () => ({
+      timers: recordTimers,
+      dailyPlayTimes
+    }),
+    [recordTimers, dailyPlayTimes]
+  )
+  const { playDays, maxPlayTimeDay } = useMemo(
+    () => ({
+      playDays: getGamePlayDays(gameId, calculationSource),
+      maxPlayTimeDay: getGameMaxPlayTimeDay(gameId, calculationSource)
+    }),
+    [gameId, calculationSource]
+  )
   const equalPlayingTime = playingTime / playDays
-  const maxPlayTimeDay = getGameMaxPlayTimeDay(gameId)
   const hasDatedPlayData = playDays > 0
 
   return (

--- a/src/renderer/src/components/Game/Record/TimerChart.tsx
+++ b/src/renderer/src/components/Game/Record/TimerChart.tsx
@@ -152,6 +152,12 @@ export const TimerChart = ({
             <ChartTooltipContent
               {...props}
               formatter={(value: ValueType) => formatGameTime((value as number) * 60 * 1000)}
+              labelFormatter={(label, payload) => {
+                if (granularity !== 'day') return label
+
+                const jumpDate = payload?.[0]?.payload?.jumpDate
+                return typeof jumpDate === 'string' ? jumpDate : label
+              }}
               hideIndicator={false}
               color="var(--primary)"
             />

--- a/src/renderer/src/components/Game/Record/TimerChart.tsx
+++ b/src/renderer/src/components/Game/Record/TimerChart.tsx
@@ -13,6 +13,10 @@ export interface DailyPlayTime {
 
 export type TimeGranularity = 'day' | 'month'
 
+export function HelpText({ info }: { info: string }): React.JSX.Element {
+  return <div className="py-6 text-center text-sm text-muted-foreground">{info}</div>
+}
+
 interface ChartData {
   jumpDate: string
   label: string
@@ -134,7 +138,9 @@ export const TimerChart = ({
       color: 'var(--primary)'
     }
   }
-  return (
+  return chartData.length === 0 ? (
+    <HelpText info={t('detail.chart.noData')} />
+  ) : (
     <ChartContainer config={chartConfig} className={cn(className)}>
       <BarChart data={chartData}>
         {/* Adding Grid Lines */}

--- a/src/renderer/src/pages/Record/MonthlyReport.tsx
+++ b/src/renderer/src/pages/Record/MonthlyReport.tsx
@@ -314,10 +314,10 @@ export function MonthlyReport(): React.JSX.Element {
       </div>
 
       <div className="grid gap-4 xl:grid-cols-[1fr_auto]">
-        {/* Weekly Play Time Chart */}
+        {/* Daily Play Time Chart */}
         <Card>
           <CardHeader className="flex flex-row">
-            <CardTitle>{t('monthly.chart.weeklyPlayTime')}</CardTitle>
+            <CardTitle>{t('monthly.chart.dailyPlayTime')}</CardTitle>
             <SettingsPopover className="flex justify-between">
               <p className="text-sm font-medium text-foreground">
                 {t('monthly.chart.useAlternateColor')}

--- a/src/renderer/src/stores/game/gameUtils.ts
+++ b/src/renderer/src/stores/game/gameUtils.ts
@@ -796,13 +796,17 @@ export function getGamePlayTimeByDateRange(
 }
 
 // Get the dates the game has been played (stored in Set)
-export function getGamePlayedDates(gameId: string): Set<string> {
+export function getGamePlayedDates(
+  gameId: string,
+  source?: GameRecordCalculationSource
+): Set<string> {
   const playDays = new Set<string>()
 
   try {
-    const store = getGameStore(gameId)
-    const timers = store.getState().getValue('record.timers')
-    const recordedDailyPlayTimes = store.getState().getValue('record.dailyPlayTimes')
+    const { timers, dailyPlayTimes: recordedDailyPlayTimes } = resolveGameRecordCalculationSource(
+      gameId,
+      source
+    )
     const dayBoundaryHour = getConfiguredDayBoundaryHour()
     let abnormalTimerCount = 0
 
@@ -810,7 +814,7 @@ export function getGamePlayedDates(gameId: string): Set<string> {
       playDays.add(item.date)
     }
 
-    for (const timer of timers || []) {
+    for (const timer of timers) {
       const startMs = new Date(timer.start).getTime()
       const endMs = new Date(timer.end).getTime()
       if (isNaN(startMs) || isNaN(endMs) || endMs <= startMs) {
@@ -839,16 +843,20 @@ export function getGamePlayedDates(gameId: string): Set<string> {
 }
 
 // Get the number of days the game has been played
-export function getGamePlayDays(gameId: string): number {
-  return getGamePlayedDates(gameId).size
+export function getGamePlayDays(gameId: string, source?: GameRecordCalculationSource): number {
+  return getGamePlayedDates(gameId, source).size
 }
 
 // Get the date of the game's maximum play time
-export function getGameMaxPlayTimeDay(gameId: string): MaxPlayTimeDay | null {
+export function getGameMaxPlayTimeDay(
+  gameId: string,
+  source?: GameRecordCalculationSource
+): MaxPlayTimeDay | null {
   try {
-    const store = getGameStore(gameId)
-    const timers = store.getState().getValue('record.timers') || []
-    const recordedDailyPlayTimes = store.getState().getValue('record.dailyPlayTimes') || []
+    const { timers, dailyPlayTimes: recordedDailyPlayTimes } = resolveGameRecordCalculationSource(
+      gameId,
+      source
+    )
     const dayBoundaryHour = getConfiguredDayBoundaryHour()
     if (timers.length === 0 && recordedDailyPlayTimes.length === 0) return null
 

--- a/src/renderer/src/stores/game/gameUtils.ts
+++ b/src/renderer/src/stores/game/gameUtils.ts
@@ -20,6 +20,24 @@ import { useGameRegistry } from './gameRegistry'
 import { getGameStore } from './gameStoreFactory'
 import { useGameCollectionStore } from './useGameCollectionStore'
 
+export interface GameRecordCalculationSource {
+  timers: gameDoc['record']['timers']
+  dailyPlayTimes: gameDoc['record']['dailyPlayTimes']
+}
+
+function resolveGameRecordCalculationSource(
+  gameId: string,
+  source?: GameRecordCalculationSource
+): GameRecordCalculationSource {
+  if (source) return source
+
+  const store = getGameStore(gameId)
+  return {
+    timers: store.getState().getValue('record.timers') || [],
+    dailyPlayTimes: store.getState().getValue('record.dailyPlayTimes') || []
+  }
+}
+
 // Search Functions
 export function searchGames(query: string, gameIds?: readonly string[]): string[] {
   if (!query.trim()) return gameIds ? [...gameIds] : useGameRegistry.getState().gameIds
@@ -709,12 +727,14 @@ export function getGamePlayTime(gameId: string): number {
 export function getGamePlayTimeByDateRange(
   gameId: string,
   startDate: string,
-  endDate: string
+  endDate: string,
+  source?: GameRecordCalculationSource
 ): { [date: string]: number } {
   try {
-    const store = getGameStore(gameId)
-    const timers = store.getState().getValue('record.timers') || []
-    const recordedDailyPlayTimes = store.getState().getValue('record.dailyPlayTimes') || []
+    const { timers, dailyPlayTimes: recordedDailyPlayTimes } = resolveGameRecordCalculationSource(
+      gameId,
+      source
+    )
     if (timers.length === 0 && recordedDailyPlayTimes.length === 0) return {}
 
     const dayBoundaryHour = getConfiguredDayBoundaryHour()
@@ -912,11 +932,15 @@ export function getGameRecord(gameId: string): gameDoc['record'] {
 }
 
 // Get game start and end dates
-export function getGameStartAndEndDate(gameId: string): { start: string; end: string } {
+export function getGameStartAndEndDate(
+  gameId: string,
+  source?: GameRecordCalculationSource
+): { start: string; end: string } {
   try {
-    const store = getGameStore(gameId)
-    const timers = store.getState().getValue('record.timers') || []
-    const recordedDailyPlayTimes = store.getState().getValue('record.dailyPlayTimes') || []
+    const { timers, dailyPlayTimes: recordedDailyPlayTimes } = resolveGameRecordCalculationSource(
+      gameId,
+      source
+    )
     const dayBoundaryHour = getConfiguredDayBoundaryHour()
     const dateKeys: string[] = []
 


### PR DESCRIPTION
### 修复了月报页面不恰当的图表标题

Fix #658 

### 修复了详情页游玩时长图表刷新不及时的问题

### 修复了详情页游玩时长图表时长筛选不生效的问题

Fix #674

### 优化了详情页游玩时长图表的悬浮提示

调整悬浮提示中的标签为显示完整的年月日，以保证游戏的游玩跨度过长时，能够有效辨识不同年份的游玩记录。

X轴标签由于空间原因仍仅显示月日。

