### PR TITLE
feat(config): make game-exit window restore optional

### DIFF
--- a/src/main/features/importer/services/versionConverter/common.ts
+++ b/src/main/features/importer/services/versionConverter/common.ts
@@ -550,6 +550,8 @@ async function convertConfig(basePath: string): Promise<void> {
       quitToTray: v2Config.general.quitToTray,
       language: '',
       hideWindowAfterGameStart: true,
+      // 旧版本没有该开关，迁移时保持原有的退出后唤起行为，避免升级改变用户体验。
+      showWindowAfterGameExit: true,
       enableForegroundTimer: true,
       foregroundWaitTime: 10,
       ignoreShortInterruptions: 0,

--- a/src/main/features/monitor/services/monitor.ts
+++ b/src/main/features/monitor/services/monitor.ts
@@ -546,6 +546,26 @@ export class GameMonitor {
     }
   }
 
+  private async restoreWindowAfterGameExit(): Promise<void> {
+    try {
+      const showWindowAfterGameExit = await ConfigDBManager.getConfigValue(
+        'general.showWindowAfterGameExit'
+      )
+      if (!showWindowAfterGameExit) {
+        return
+      }
+
+      const mainWindow = BrowserWindow.getAllWindows()[0]
+      if (mainWindow) {
+        mainWindow.show()
+        mainWindow.focus()
+      }
+    } catch (error) {
+      // 窗口恢复属于非关键体验；读取或显示失败不能阻断退出事件和时长保存。
+      log.warn('[Monitor] Failed to restore the window after game exit:', error)
+    }
+  }
+
   // Do not require mutex in this method, this will result in a dead lock
   private async handleGameExit(): Promise<void> {
     if (this.exiting) {
@@ -561,10 +581,8 @@ export class GameMonitor {
     // Record end time
     this.endTime = new Date().toISOString()
 
-    const mainWindow = BrowserWindow.getAllWindows()[0]
-
-    mainWindow.show()
-    mainWindow.focus()
+    // 窗口恢复与退出收尾并行执行，避免非关键配置读取拖住退出事件和时长保存。
+    void this.restoreWindowAfterGameExit()
 
     ipcManager.send('game:exiting', this.options.gameId)
 

--- a/src/renderer/locales/en/config.json
+++ b/src/renderer/locales/en/config.json
@@ -18,6 +18,8 @@
     "minimizeToTray": "Minimize to Tray",
     "hideWindowAfterGameStart": "Minimize to tray after game launch",
     "hideWindowAfterGameStartDescription": "Automatically hide main window after launching a game",
+    "showWindowAfterGameExit": "Show main window after game exit",
+    "showWindowAfterGameExitDescription": "Automatically show and focus the Vnite main window after a game exits",
     "timerTitle": "Game Timer",
     "foregroundTimer": {
       "title": "Foreground Timer",

--- a/src/renderer/locales/fr/config.json
+++ b/src/renderer/locales/fr/config.json
@@ -13,7 +13,9 @@
     "quitApp": "",
     "minimizeToTray": "",
     "languageDescription": "Choisissez la langue d'affichage pour l'application",
-    "openAtLoginDescription": "Ouvrir automatiquement l'application au démarrage du système"
+    "openAtLoginDescription": "Ouvrir automatiquement l'application au démarrage du système",
+    "showWindowAfterGameExit": "Afficher la fenêtre principale après la fermeture du jeu",
+    "showWindowAfterGameExitDescription": "Afficher automatiquement la fenêtre principale de Vnite et la mettre au premier plan après la fermeture d'un jeu"
   },
   "appearances": {
     "title": "",

--- a/src/renderer/locales/it/config.json
+++ b/src/renderer/locales/it/config.json
@@ -12,7 +12,9 @@
     "action": "",
     "quitApp": "",
     "minimizeToTray": "",
-    "hideWindowAfterGameStart": ""
+    "hideWindowAfterGameStart": "",
+    "showWindowAfterGameExit": "Mostra la finestra principale dopo l'uscita dal gioco",
+    "showWindowAfterGameExitDescription": "Mostra automaticamente la finestra principale di Vnite e portala in primo piano dopo l'uscita da un gioco"
   },
   "appearances": {
     "title": "",

--- a/src/renderer/locales/ja/config.json
+++ b/src/renderer/locales/ja/config.json
@@ -18,6 +18,8 @@
     "minimizeToTray": "トレイに最小化",
     "hideWindowAfterGameStart": "ゲーム起動後にトレイに最小化する",
     "hideWindowAfterGameStartDescription": "ゲーム起動後に自動的にメインウィンドウを隠す",
+    "showWindowAfterGameExit": "ゲーム終了後にメインウィンドウを表示",
+    "showWindowAfterGameExitDescription": "ゲームの終了を検出した後、Vnite のメインウィンドウを自動的に表示して前面に切り替える",
     "timerTitle": "ゲームタイマー",
     "foregroundTimer": {
       "title": "フォアグラウンドタイマー",

--- a/src/renderer/locales/ko/config.json
+++ b/src/renderer/locales/ko/config.json
@@ -13,11 +13,13 @@
     "quitApp": "Vnite 종료",
     "minimizeToTray": "트레이로 최소화",
     "hideWindowAfterGameStart": "게임 실행 후 트레이로 최소화",
+    "showWindowAfterGameExit": "게임 종료 후 메인 창 표시",
     "languageDescription": "어플리케이션에 표시될 언어를 선택해주세요",
     "openAtLoginDescription": "시스템 시작시 자동으로 실행",
     "themeDescription": "어플리케이션에 적용할 테마를 선택해주세요",
     "closeMainPanelDescription": "메인 창을 닫을 때의 행동을 선택해주세요",
-    "hideWindowAfterGameStartDescription": "게임을 실행한 후 메인 창을 자동으로 숨깁니다"
+    "hideWindowAfterGameStartDescription": "게임을 실행한 후 메인 창을 자동으로 숨깁니다",
+    "showWindowAfterGameExitDescription": "게임 종료가 감지되면 Vnite 메인 창을 자동으로 표시하고 앞으로 가져옵니다"
   },
   "appearances": {
     "title": "표시",

--- a/src/renderer/locales/ru/config.json
+++ b/src/renderer/locales/ru/config.json
@@ -11,7 +11,9 @@
     "closeMainPanel": "Закрывать главное окно",
     "action": "Действие",
     "quitApp": "Выйти из Vnite",
-    "minimizeToTray": "Свернуть в трей"
+    "minimizeToTray": "Свернуть в трей",
+    "showWindowAfterGameExit": "Показывать главное окно после выхода из игры",
+    "showWindowAfterGameExitDescription": "Автоматически показывать главное окно Vnite и переводить его на передний план после выхода из игры"
   },
   "appearances": {
     "title": "Внешний вид",

--- a/src/renderer/locales/uk/config.json
+++ b/src/renderer/locales/uk/config.json
@@ -18,6 +18,8 @@
     "minimizeToTray": "Згорнути в лоток",
     "hideWindowAfterGameStart": "Згортати в лоток після запуску гри",
     "hideWindowAfterGameStartDescription": "Автоматично ховати головне вікно після запуску гри",
+    "showWindowAfterGameExit": "Показувати головне вікно після завершення гри",
+    "showWindowAfterGameExitDescription": "Автоматично показувати головне вікно Vnite та переводити його на передній план після завершення гри",
     "timerTitle": "Ігровий таймер",
     "foregroundTimer": {
       "title": "Таймер переднього плану",

--- a/src/renderer/locales/zh-CN/config.json
+++ b/src/renderer/locales/zh-CN/config.json
@@ -18,6 +18,8 @@
     "minimizeToTray": "最小化到托盘",
     "hideWindowAfterGameStart": "启动游戏后最小化到托盘",
     "hideWindowAfterGameStartDescription": "启动游戏后自动隐藏主窗口",
+    "showWindowAfterGameExit": "游戏退出后显示主窗口",
+    "showWindowAfterGameExitDescription": "检测到游戏退出后，自动显示 Vnite 并将其切换到前台",
     "timerTitle": "游戏计时器",
     "foregroundTimer": {
       "title": "前台计时",

--- a/src/renderer/locales/zh-TW/config.json
+++ b/src/renderer/locales/zh-TW/config.json
@@ -18,6 +18,8 @@
     "minimizeToTray": "最小化到系統匣",
     "hideWindowAfterGameStart": "啟動遊戲後最小化到系統匣",
     "hideWindowAfterGameStartDescription": "啟動遊戲後自動隱藏主窗口",
+    "showWindowAfterGameExit": "遊戲結束後顯示主視窗",
+    "showWindowAfterGameExitDescription": "偵測到遊戲結束後，自動顯示 Vnite 並將其切換到前景",
     "timerTitle": "游戲計時器",
     "foregroundTimer": {
       "title": "前臺計時",

--- a/src/renderer/src/pages/Config/General.tsx
+++ b/src/renderer/src/pages/Config/General.tsx
@@ -128,6 +128,15 @@ export function General(): React.JSX.Element {
             controlType="switch"
           />
 
+          {/* 默认延续现有的退出后唤起行为，同时允许用户按需关闭。 */}
+          <ConfigItem
+            hookType="config"
+            path="general.showWindowAfterGameExit"
+            title={t('general.showWindowAfterGameExit')}
+            description={t('general.showWindowAfterGameExitDescription')}
+            controlType="switch"
+          />
+
           {/* Foreground Window Settings */}
           <div className={cn('space-y-4')}>
             <div className={cn('border-b pb-2')}>{t('general.timerTitle')}</div>

--- a/src/types/models/config.ts
+++ b/src/types/models/config.ts
@@ -34,6 +34,7 @@ export interface configDocs {
     quitToTray: boolean
     language: string
     hideWindowAfterGameStart: boolean
+    showWindowAfterGameExit: boolean
     enableForegroundTimer: boolean
     foregroundWaitTime: number
     ignoreShortInterruptions: number
@@ -363,6 +364,8 @@ export const DEFAULT_CONFIG_VALUES: Readonly<configDocs> = {
     quitToTray: false,
     language: '',
     hideWindowAfterGameStart: true,
+    // 默认延续现有版本的退出行为，升级后仍会显示并聚焦主窗口，用户可在设置中关闭。
+    showWindowAfterGameExit: true,
     enableForegroundTimer: true,
     foregroundWaitTime: 10,
     ignoreShortInterruptions: 0,


### PR DESCRIPTION
Keep the main window hidden by default when a game exits, while allowing users to opt into the previous show-and-focus behavior.