### PR TITLE
fix(image): decode Steam 10-bit AVIF images with jSquash

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,6 +1,6 @@
-import { resolve } from 'path'
-import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import react from '@vitejs/plugin-react'
+import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
+import { resolve } from 'path'
 // @ts-ignore moduleResolution problem with tailwindcss
 import tailwindcss from '@tailwindcss/vite'
 
@@ -15,7 +15,21 @@ export default defineConfig({
         '@resources': resolve('resources')
       }
     },
-    plugins: [externalizeDepsPlugin({ exclude: ['electron-context-menu'] })]
+    plugins: [
+      externalizeDepsPlugin({
+        exclude: [
+          'electron-context-menu',
+          // @jsquash/avif is kept as a devDependency so electron-builder does not copy
+          // the entire package. Rollup instead bundles only the imported decoder code
+          // and WASM asset.
+          //
+          // The package is ESM-only and must be bundled for the CJS main-process output.
+          // Although devDependencies are not normally externalized, keep this exclusion
+          // explicitly to ensure it remains bundled if its dependency classification changes.
+          '@jsquash/avif'
+        ]
+      })
+    ]
   },
   preload: {
     plugins: [externalizeDepsPlugin()]

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@electron-toolkit/tsconfig": "^1.0.1",
     "@iconify/json": "^2.2.357",
     "@iconify/tailwind4": "^1.0.6",
+    "@jsquash/avif": "2.1.1",
     "@tailwindcss/typography": "^0.5.16",
     "@types/adm-zip": "^0.5.7",
     "@types/archiver": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       '@iconify/tailwind4':
         specifier: ^1.0.6
         version: 1.0.6(tailwindcss@4.1.11)
+      '@jsquash/avif':
+        specifier: 2.1.1
+        version: 2.1.1
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.11)
@@ -1369,6 +1372,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+
+  '@jsquash/avif@2.1.1':
+    resolution: {integrity: sha512-LMRxd0fMgfCLtobDh0/sFYJMMiRJTNYSEEWvRDKXlAeZ08t3gI5V+1thIT0XjXJ+SVG7Zug9B0XPyx0Ti5VRNA==}
 
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
@@ -6792,6 +6798,9 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  wasm-feature-detect@1.9.0:
+    resolution: {integrity: sha512-zonE+xlIIYtxPy++L24ow0hAD8CICb4+FgPyROd3buyXIqsJvUEDkBgfCCoXOd1Hu3DUr0GOfnPIdcGV+YpNaA==}
+
   wawoff2@2.0.1:
     resolution: {integrity: sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==}
     hasBin: true
@@ -7987,6 +7996,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
+
+  '@jsquash/avif@2.1.1':
+    dependencies:
+      wasm-feature-detect: 1.9.0
 
   '@lezer/common@1.5.2': {}
 
@@ -14293,6 +14306,8 @@ snapshots:
   vuvuzela@1.0.3: {}
 
   w3c-keyname@2.2.8: {}
+
+  wasm-feature-detect@1.9.0: {}
 
   wawoff2@2.0.1:
     dependencies:

--- a/src/main/jsquash-avif.d.ts
+++ b/src/main/jsquash-avif.d.ts
@@ -1,0 +1,13 @@
+// Node-specific type corrections used by the main process:
+// - init accepts a precompiled WebAssembly module.
+// - decode accepts a Node Buffer and returns the default 8-bit ImageData output.
+//
+// Only the signatures currently used by the application are declared here.
+declare module '@jsquash/avif/decode.js' {
+  export function init(module: WebAssembly.Module): Promise<void>
+
+  export default function decode(
+    input: Buffer<ArrayBufferLike>,
+    options?: { bitDepth?: 8 }
+  ): Promise<ImageData | null>
+}

--- a/src/main/utils/image.ts
+++ b/src/main/utils/image.ts
@@ -1,4 +1,6 @@
 import { getUpscalerBackendByPath, type GameImageUpscaleOptions } from '@appTypes/utils'
+import avifDecoderWasmPath from '@jsquash/avif/codec/dec/avif_dec.wasm?asset'
+import decodeAvif, { init as initAvifDecoder } from '@jsquash/avif/decode.js'
 import { Mutex } from 'async-mutex'
 import { spawn } from 'child_process'
 import { clipboard, net } from 'electron'
@@ -128,6 +130,40 @@ export async function convertToWebP(
         .toBuffer()
     }
 
+    const fileType = await fileTypeFromBuffer(imageBuffer as Uint8Array)
+
+    // Under ISO BMFF, AVIF may be declared as either the major brand or a compatible
+    // brand. When AVIF appears only as a compatible brand, file-type reports generic HEIF.
+    // Although generic HEIF may also represent HEIC, but there is no current need to support it.
+    if (fileType?.mime === 'image/avif' || fileType?.mime === 'image/heif') {
+      // Some images in Steam descriptions use 10-bit AVIF, which Sharp cannot decode.
+      // To keep this conversion path simple, route all AVIF input through @jsquash/avif.
+      // This API exposes only a single frame, so animated AVIF is not preserved.
+      await ensureAvifDecoder()
+      const imageData = await decodeAvif(imageBuffer)
+      if (!imageData) {
+        throw new Error('Failed to decode image as AVIF')
+      }
+
+      const pixels = Buffer.from(
+        imageData.data.buffer,
+        imageData.data.byteOffset,
+        imageData.data.byteLength
+      )
+
+      return await sharp(pixels, {
+        raw: {
+          width: imageData.width,
+          height: imageData.height,
+          channels: 4
+        }
+      })
+        .webp({
+          quality: options.quality ?? 100
+        })
+        .toBuffer()
+    }
+
     const metadata = await sharp(imageBuffer).metadata()
 
     let isAnimated = false
@@ -182,6 +218,21 @@ function isIcoFormat(buffer: Buffer): boolean {
     return buffer[0] === 0 && buffer[1] === 0 && buffer[2] === 1 && buffer[3] === 0
   }
   return false
+}
+
+let avifDecoderInitialization: Promise<void> | undefined
+
+async function ensureAvifDecoder(): Promise<void> {
+  avifDecoderInitialization ??= (async () => {
+    const wasmBuffer = await fse.readFile(avifDecoderWasmPath)
+    const wasmModule = await WebAssembly.compile(Uint8Array.from(wasmBuffer))
+
+    // Follow jSquash's Node integration pattern by loading and compiling WASM explicitly:
+    // https://github.com/jamsinclair/jSquash/blob/main/examples/with-node/index.js
+    await initAvifDecoder(wasmModule)
+  })()
+
+  return avifDecoderInitialization
 }
 
 export async function cropImage({


### PR DESCRIPTION
### 修复Steam 10-bit AVIF 资源无法缓存的问题

经过多方对比评判后，并没有使用前期初步决定的`icodec`，而是使用`@jsquash/avif`作为解决方案。

对于这个影响范围极窄的问题而言，后者引入的依赖更为轻量集中，同时其API使用起来也更为便捷。

同时考虑了引入该修复对打包体积的影响，目前只有用到的AVIF解码器与特定WASM会被打包进最终产物，影响足够可控。

Fix #607