### PR TITLE
fix: game with non-ascii path can't be terminated by UI button

### DIFF
--- a/src/main/features/monitor/services/monitor.ts
+++ b/src/main/features/monitor/services/monitor.ts
@@ -1,19 +1,17 @@
-import path from 'path'
-import fse from 'fs-extra'
-import { ipcMain, BrowserWindow } from 'electron'
-import { simulateHotkey } from '~/utils'
-import { updateRecentGamesInTray } from '~/features/system'
-import { GameDBManager, ConfigDBManager } from '~/core/database'
-import log from 'electron-log/main.js'
-import { backupGameSave } from '~/features/game'
-import { spawn } from 'child_process'
-import { psManager } from '~/utils'
-import { ipcManager } from '~/core/ipc'
-import { eventBus } from '~/core/events'
-import { ActiveGameInfo } from '~/features/game'
-import { Mutex } from 'async-mutex'
-import { removeMonitorStub } from './nativeMonitor'
 import { TimerStatus } from '@appTypes/models'
+import { Mutex } from 'async-mutex'
+import { spawn } from 'child_process'
+import { BrowserWindow, ipcMain } from 'electron'
+import log from 'electron-log/main.js'
+import fse from 'fs-extra'
+import path from 'path'
+import { ConfigDBManager, GameDBManager } from '~/core/database'
+import { eventBus } from '~/core/events'
+import { ipcManager } from '~/core/ipc'
+import { ActiveGameInfo, backupGameSave } from '~/features/game'
+import { updateRecentGamesInTray } from '~/features/system'
+import { psManager, simulateHotkey } from '~/utils'
+import { removeMonitorStub } from './nativeMonitor'
 
 async function getProcessList(): Promise<
   Array<{
@@ -165,6 +163,7 @@ export class GameMonitor {
       const isProcessNameMode = process.isProcessNameMode === true
 
       if (isProcessNameMode) {
+        // NOTE: This legacy branch is unused by native monitoring; its command safety is unchecked.
         // Process name mode, use the process name directly
         const processName = process.path
         console.log(`Try to terminate process by name: ${processName}`)
@@ -195,13 +194,17 @@ export class GameMonitor {
       } else {
         // Normalize the path
         const normalizedPath = this.normalizePath(process.path)
+        // PowerShell treats the following five characters as single-quote tokens, so all must be escaped.
+        const escapedPath = normalizedPath.replace(/['\u2018\u2019\u201a\u201b]/g, (quote) =>
+          quote.repeat(2)
+        )
         const processName = path.basename(normalizedPath)
 
         console.log(`Try to terminate process: ${normalizedPath}`)
 
         try {
           // Use PowerShell to terminate the process by exact path
-          const psCommand = `Get-Process | Where-Object {$_.Path -eq '${normalizedPath}'} | Stop-Process -Force`
+          const psCommand = `Get-Process | Where-Object {$_.Path -eq '${escapedPath}'} | Stop-Process -Force`
           await psManager.executeCommand(psCommand)
           console.log(`Process ${processName} has been terminated successfully.`)
           return true

--- a/src/main/features/monitor/services/monitor.ts
+++ b/src/main/features/monitor/services/monitor.ts
@@ -10,7 +10,7 @@ import { eventBus } from '~/core/events'
 import { ipcManager } from '~/core/ipc'
 import { ActiveGameInfo, backupGameSave } from '~/features/game'
 import { updateRecentGamesInTray } from '~/features/system'
-import { psManager, simulateHotkey } from '~/utils'
+import { psManager, simulateHotkey, toPowerShellStringLiteral } from '~/utils'
 import { removeMonitorStub } from './nativeMonitor'
 
 async function getProcessList(): Promise<
@@ -194,17 +194,14 @@ export class GameMonitor {
       } else {
         // Normalize the path
         const normalizedPath = this.normalizePath(process.path)
-        // PowerShell treats the following five characters as single-quote tokens, so all must be escaped.
-        const escapedPath = normalizedPath.replace(/['\u2018\u2019\u201a\u201b]/g, (quote) =>
-          quote.repeat(2)
-        )
+        const pathLiteral = toPowerShellStringLiteral(normalizedPath)
         const processName = path.basename(normalizedPath)
 
         console.log(`Try to terminate process: ${normalizedPath}`)
 
         try {
           // Use PowerShell to terminate the process by exact path
-          const psCommand = `Get-Process | Where-Object {$_.Path -eq '${escapedPath}'} | Stop-Process -Force`
+          const psCommand = `Get-Process | Where-Object {$_.Path -eq ${pathLiteral}} | Stop-Process -Force`
           await psManager.executeCommand(psCommand)
           console.log(`Process ${processName} has been terminated successfully.`)
           return true

--- a/src/main/utils/common.ts
+++ b/src/main/utils/common.ts
@@ -11,7 +11,7 @@ import pngToIco from 'png-to-ico'
 import sharp from 'sharp'
 import { promisify } from 'util'
 import { getAppTempPath, getDataPath } from '~/features/system'
-import { psManager } from './powershell'
+import { psManager, toPowerShellStringLiteral } from './powershell'
 
 const execAsync = promisify(exec)
 
@@ -90,11 +90,12 @@ export async function copyFileToClipboard(filePath: string): Promise<boolean> {
 
     // Ensure absolute path is used
     const absolutePath = path.resolve(filePath)
+    const pathLiteral = toPowerShellStringLiteral(absolutePath)
 
     // PowerShell command: Add the file to clipboard
     const psCommand = `
       Add-Type -AssemblyName System.Windows.Forms
-      $filePath = "${absolutePath.replace(/\\/g, '\\\\')}"
+      $filePath = ${pathLiteral}
       $fileCollection = New-Object System.Collections.Specialized.StringCollection
       $fileCollection.Add($filePath) | Out-Null
       [System.Windows.Forms.Clipboard]::SetFileDropList($fileCollection)

--- a/src/main/utils/powershell.ts
+++ b/src/main/utils/powershell.ts
@@ -1,6 +1,16 @@
 import { ChildProcess, spawn } from 'child_process'
 import log from 'electron-log/main'
 
+/**
+ * Escapes PowerShell single-quote tokens and returns the value as a single-quoted string literal.
+ */
+export function toPowerShellStringLiteral(value: string): string {
+  // PowerShell treats the following five characters as single-quote tokens, so all must be escaped.
+  const escapedValue = value.replace(/['\u2018\u2019\u201a\u201b]/g, (quote) => quote.repeat(2))
+
+  return `'${escapedValue}'`
+}
+
 class PowerShellManager {
   private psProcess: ChildProcess | null = null
   private isInitialized = false

--- a/src/main/utils/powershell.ts
+++ b/src/main/utils/powershell.ts
@@ -1,4 +1,4 @@
-import { spawn, ChildProcess } from 'child_process'
+import { ChildProcess, spawn } from 'child_process'
 import log from 'electron-log/main'
 
 class PowerShellManager {
@@ -140,9 +140,20 @@ class PowerShellManager {
       this.psProcess.stdout.on('data', onData)
       this.psProcess.stderr?.on('data', onError)
 
-      // Process the command and add the delimiter
-      const fullCommand = `${command}; Write-Host "${delimiter}"\n`
-      this.psProcess.stdin?.write(fullCommand)
+      // Encode the command so only ASCII characters are sent through PowerShell's stdin.
+      // PowerShell explicitly decodes it as UTF-8 before execution, avoiding console code page issues.
+      const encodedCommand = Buffer.from(command, 'utf8').toString('base64')
+      const fullCommand = `
+        & (
+          [ScriptBlock]::Create(
+            [Text.Encoding]::UTF8.GetString(
+              [Convert]::FromBase64String('${encodedCommand}')
+            )
+          )
+        );
+        Write-Host "${delimiter}"
+      `
+      this.psProcess.stdin?.write(`${fullCommand}\n`)
     })
   }
 


### PR DESCRIPTION
### 修复游戏无法通过界面按钮结束的问题

对于路径中存在非 ASCII 字符的游戏，当前终止游戏使用的 PowerShell 进程有极大的概率解析出错，进而导致构建出的查询命令中的路径条件乱码，无法正确终止游戏。

检查发现，虽然目前初始化 PowerShell 时有执行 `chcp 65001 `修改活动代码页，但是该设置完全无法影响已经建立的 stdin 管道的输入解码方式，导致程序传入 PowerShell 的 UTF8 字符无法正确解码。

该提交修改了 PowerShell 的命令传入层，提前将命令编码为 Base64 传入，随后在 PowerShell 内部 Base64 输入被解析为脚本块对象执行。该方案能够保证传入的内容由纯 ASCII 字符组成，因此能够规避解码问题。

```powershell
& (
  [ScriptBlock]::Create(
    [Text.Encoding]::UTF8.GetString(
      [Convert]::FromBase64String('${encodedCommand}')
    )
  )
);
```

此外，还修复了 PowerShell 命令构建上的细节问题，如移除了不必要的反斜杠转义、添加了必要的单引号转义、将双引号字符串修改为单引号字面字符串以避免意外的内容执行。